### PR TITLE
Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
  - git lfs install  
  # Download data.
  - cd SwE-toolbox/test/data
- - if ! [ -d .git ]; git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
+ - if ! [ -d .git ]; then git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git reset --hard origin/master
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
  - if ! [ -d .git ]; then git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git reset --hard origin/master
- - ls
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
  - travis_retry git reset --hard origin/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
   - docker
 cache: 
   timeout: 1000
-#  directories:
-#  - test/data
+  directories:
+  - test/data
 python:
   - "3.5"
 bundler_args: --retry 9
@@ -21,10 +21,10 @@ install:
  - cd SwE-toolbox/test/data
  - if ! [ -d .git ]; then git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files)
- #- travis_retry git reset --hard origin/master
+ - travis_retry git reset --hard origin/master
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
- #- travis_retry git reset --hard origin/master
+ - travis_retry git reset --hard origin/master
  - cd ../..
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
   - docker
 cache: 
   timeout: 1000
-  directories:
-  - test/data
+#  directories:
+#  - test/data
 python:
   - "3.5"
 bundler_args: --retry 9
@@ -21,10 +21,10 @@ install:
  - cd SwE-toolbox/test/data
  - if ! [ -d .git ]; then git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files)
- - travis_retry git reset --hard origin/master
+ #- travis_retry git reset --hard origin/master
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
- - travis_retry git reset --hard origin/master
+ #- travis_retry git reset --hard origin/master
  - cd ../..
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
  - if ! [ -d .git ]; then git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files)
  - travis_retry git reset --hard origin/master
+ - ls
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
  - travis_retry git reset --hard origin/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
   - docker
 cache: 
   timeout: 1000
+  directories:
+  - test/data
 python:
   - "3.5"
 bundler_args: --retry 9
@@ -16,9 +18,14 @@ install:
  - export PATH=$PATH:`pwd`/git-lfs-1.4.1
  - git lfs install  
  # Download data.
- - cd SwE-toolbox/test
- - git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git data
- - cd ..
+ - cd SwE-toolbox/test/data
+ - if ! [ -d .git ]; git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
+ # Delete any previous changes (retry because lfs might download files)
+ - travis_retry git reset --hard origin/master
+ # A second time to allow for 3 more retries as "--retry 9" does not seem to be
+ # taken into account by Travis CI
+ - travis_retry git reset --hard origin/master
+ - cd ../..
 jobs:
   include:
     - stage: Results generation 

--- a/swe_cfg_design.m
+++ b/swe_cfg_design.m
@@ -545,23 +545,6 @@ WB_no.help    = {''
   'Only a "standard" parametric SwE analysis is considered'};
 
 % ---------------------------------------------------------------------
-% WB_type WB_type
-% ---------------------------------------------------------------------
-WB_type         = cfg_menu;
-WB_type.tag     = 'WB_type';
-WB_type.name    = 'Type of resampling';
-WB_type.labels     = {'U-WB' 'R-WB'};
-WB_type.values     = {0 1};
-WB_type.val     = {1};
-WB_type.help    = {''
-  'U-WB: unrestricted WB which based the resampling on the unrestricted model (not imposing the null hypothesis)'
-  ''
-  'R-WB: restricted WB which based the resampling on the restricted model (imposing the null hypothesis)'
-  ''
-  'Monte Carlo simulations (see Guillaume, 2015) indicates that the R-WB generally outperforms the U-WB and, therefore, it seems preferable to always use this WB version. The U-WB option is currently available, but nothing indicates that it should be used and thus might be removed later.'
-  ''
-  };
-% ---------------------------------------------------------------------
 % WB_SwE type of SwE
 % ---------------------------------------------------------------------
 WB_SwE         = cfg_menu;
@@ -786,7 +769,7 @@ WB_cluster.help    = {''
 WB_yes         = cfg_branch;
 WB_yes.tag     = 'WB_yes';
 WB_yes.name    = 'Yes';
-WB_yes.val     = {WB_type WB_ss WB_nB WB_SwE WB_stat WB_cluster};
+WB_yes.val     = {WB_ss WB_nB WB_SwE WB_stat WB_cluster};
 WB_yes.help    = {''
                      'A non-parametric Wild Bootstrap procedure is considered to analyse the data (see Guillaume, 2015)'
 }';

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -2050,7 +2050,7 @@ function [corr, tmpR2] = swe_resid_corr(SwE, restric, ss, pX, varargin)
     conWB = SwE.WB.con;
     iSubj = SwE.Subj.iSubj;
     nSubj = SwE.Subj.nSubj;
-    uSubj = SwE.Subj.uSubj;
+    uSubj = SwE.Subj.uSubj; 
     rankCon = rank(SwE.WB.con);
 
     % This is to prevent tmpR2 being overwritten.

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -135,7 +135,7 @@ if isMat && WB.clusterWise == 1
 end
 
 % small sample correction (for WB)
-[corrWB, tmpR2] = swe_resid_corr(SwE, WB.RWB, WB.SS, pX);
+[corrWB, tmpR2] = swe_resid_corr(SwE, 1, WB.SS, pX);
 
 % small sample correction (for parametric)
 [corr, tmpR2] = swe_resid_corr(SwE, WB.RSwE, SwE.SS, pX, tmpR2);
@@ -500,11 +500,7 @@ if ~isMat
   %----------------------------------------------------------------------
   
   for i = 1:nScan
-      if WB.RWB == 1
-        descrip = sprintf('adjusted restricted residuals (%04d)', i);
-      else
-        descrip = sprintf('adjusted unrestricted residuals (%04d)', i);
-      end
+      descrip = sprintf('adjusted restricted residuals (%04d)', i);
       VResWB(i) = swe_create_vol(sprintf('swe_vox_resid_y%04d%s', i, file_ext), DIM, M, descrip);
   end
   
@@ -514,11 +510,7 @@ if ~isMat
   %----------------------------------------------------------------------
   
   for i = 1:nScan
-      if WB.RWB == 1
-         descrip = sprintf('restricted fitted data  (%04d)', i);
-      else
-         descrip = sprintf('unrestricted fitted data (%04d)', i);
-      end
+      descrip = sprintf('restricted fitted data  (%04d)', i);
       VYWB(i) = swe_create_vol(sprintf('swe_vox_fit_y%04d%s',i,file_ext), DIM, M, descrip);
   end
   
@@ -703,11 +695,7 @@ if ~isMat
         beta  = pX*Y;                     %-Parameter estimates
         
         % restricted fitted data
-        if WB.RWB == 1
-            [resWB, YWB]=swe_fit(SwE, Y, tmpR2, corrWB, beta, SwE.WB.SS);
-        else 
-            [resWB, YWB]=swe_fit(SwE, Y, xX.X, corrWB, beta, SwE.WB.SS);
-        end
+        [resWB, YWB]=swe_fit(SwE, Y, tmpR2, corrWB, beta, SwE.WB.SS);
 
         if WB.RSwE == 1
             res=swe_fit(SwE, Y, tmpR2, corr, beta, SwE.SS);
@@ -1005,11 +993,7 @@ else % ".mat" format
     
     beta  = pX*Y;                     %-Parameter estimates
     
-    if WB.RWB == 1
-        [resWB, YWB]=swe_fit(SwE, Y, tmpR2, corrWB, beta, SwE.WB.SS);
-    else 
-        [resWB, YWB]=swe_fit(SwE, Y, xX.X, corrWB, beta, SwE.WB.SS);
-    end
+    [resWB, YWB]=swe_fit(SwE, Y, tmpR2, corrWB, beta, SwE.WB.SS);
     
     if WB.RSwE == 1
         res=swe_fit(SwE, Y, tmpR2, corr, beta, SwE.SS);
@@ -1240,9 +1224,8 @@ SwE.WB.weightR    = weightR;
 SwE.WB.corrWB     = corrWB;
 SwE.WB.corr       = corr;
 
-if SwE.WB.RWB == 1 || SwE.WB.RSwE == 1
-  SwE.WB.tmpR2      = tmpR2;
-end
+SwE.WB.tmpR2      = tmpR2;
+
 
 % cluster-wise specific fields if needed
 if (SwE.WB.clusterWise == 1)

--- a/swe_run_design.m
+++ b/swe_run_design.m
@@ -663,7 +663,6 @@ fprintf('%30s\n','...done')                                             %-#
 %==========================================================================
 if isfield(job.WB, 'WB_yes')
   
-  WB.RWB            = job.WB.WB_yes.WB_type;
   WB.SS             = job.WB.WB_yes.WB_ss;
   WB.nB             = job.WB.WB_yes.WB_nB;
   WB.RSwE           = job.WB.WB_yes.WB_SwE;

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -70,8 +70,8 @@ function testSetup(porwb, torf, matorimg)
 	addpath('/swe');
 	addpath('/swe/test');
     
-    % Run teardown method just in case some of the files managed to get
-    % cached.
+    % Run teardown method just in case some of the files from the previous 
+    % run managed to get cached.
     testTearDown(porwb, torf, matorimg);
 
 	% Reset all seeds 
@@ -252,7 +252,7 @@ function testTearDown(porwb, torf, matorimg)
 	delete('swe_*')
 	delete('SwE*')
 
-	if exist('xSwE.mat')~=0
+	if exist('xSwE_orig.mat')~=0
 		delete('xSwE.mat')
 		rename('xSwE_orig.mat', 'xSwE.mat')
 	end

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -69,6 +69,10 @@ function testSetup(porwb, torf, matorimg)
 	ls;
 	addpath('/swe');
 	addpath('/swe/test');
+    
+    % Run teardown method just in case some of the files managed to get
+    % cached.
+    testTearDown(porwb, torf, matorimg);
 
 	% Reset all seeds 
 	% (Footnote: In octave these are all different!!).

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -8,7 +8,7 @@
 % matorimg - 'mat' for '.mat' file surface input pr 'img' for '.img' and '.hdr' 
 %			 volumetric input.
 %
-% Author: Tom Maullin (08/06/20178)
+% Author: Tom Maullin (08/06/20178) 
 %
 %=======================================================================================
 

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -25,37 +25,37 @@ function result=runTest(porwb, torf, matorimg)
 	% Work out which test we are running.
 	testname = [porwb '_' torf '_' matorimg];
 
-	% Tell the user which test case we are running.
-	disp(sprintf('\n=============================================================='))
-	disp(['Test case running: ' testname])
-	disp(sprintf('==============================================================\n'))
-
-	% Test setup
-	testSetup(porwb, torf, matorimg)
-
-	% Generate the results for the test.
-	generateData(porwb, torf, matorimg);
-
-
-	% Tell the user we have run the test.
-	disp(sprintf('\n=============================================================='))
-	disp(['Test case ' testname ' has been run.'])
-	disp('--------------------------------------------------------------')
-	disp('Verifying test results')
-	disp(sprintf('==============================================================\n'))
-
-	% Compare test results to ground truth.
-	result = verifyMapsUnchanged(porwb, torf, matorimg);
-
-	% Tell the user whether the tests passed.
-	disp(sprintf('\n=============================================================='))
-	if ~result
-		disp('A test has failed!')
-		error(['Test ' testname ' has failed.'])
-	else
-		disp('All tests pass!!')
-	end
-	disp(sprintf('==============================================================\n'))
+% 	% Tell the user which test case we are running.
+% 	disp(sprintf('\n=============================================================='))
+% 	disp(['Test case running: ' testname])
+% 	disp(sprintf('==============================================================\n'))
+% 
+% 	% Test setup
+% 	testSetup(porwb, torf, matorimg)
+% 
+% 	% Generate the results for the test.
+% 	generateData(porwb, torf, matorimg);
+% 
+% 
+% 	% Tell the user we have run the test.
+% 	disp(sprintf('\n=============================================================='))
+% 	disp(['Test case ' testname ' has been run.'])
+% 	disp('--------------------------------------------------------------')
+% 	disp('Verifying test results')
+% 	disp(sprintf('==============================================================\n'))
+% 
+% 	% Compare test results to ground truth.
+% 	result = verifyMapsUnchanged(porwb, torf, matorimg);
+% 
+% 	% Tell the user whether the tests passed.
+% 	disp(sprintf('\n=============================================================='))
+% 	if ~result
+% 		disp('A test has failed!')
+% 		error(['Test ' testname ' has failed.'])
+% 	else
+% 		disp('All tests pass!!')
+% 	end
+% 	disp(sprintf('==============================================================\n'))
 
 	% Teardown method
 	testTearDown(porwb, torf, matorimg)

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -25,37 +25,37 @@ function result=runTest(porwb, torf, matorimg)
 	% Work out which test we are running.
 	testname = [porwb '_' torf '_' matorimg];
 
-% 	% Tell the user which test case we are running.
-% 	disp(sprintf('\n=============================================================='))
-% 	disp(['Test case running: ' testname])
-% 	disp(sprintf('==============================================================\n'))
-% 
-% 	% Test setup
-% 	testSetup(porwb, torf, matorimg)
-% 
-% 	% Generate the results for the test.
-% 	generateData(porwb, torf, matorimg);
-% 
-% 
-% 	% Tell the user we have run the test.
-% 	disp(sprintf('\n=============================================================='))
-% 	disp(['Test case ' testname ' has been run.'])
-% 	disp('--------------------------------------------------------------')
-% 	disp('Verifying test results')
-% 	disp(sprintf('==============================================================\n'))
-% 
-% 	% Compare test results to ground truth.
-% 	result = verifyMapsUnchanged(porwb, torf, matorimg);
-% 
-% 	% Tell the user whether the tests passed.
-% 	disp(sprintf('\n=============================================================='))
-% 	if ~result
-% 		disp('A test has failed!')
-% 		error(['Test ' testname ' has failed.'])
-% 	else
-% 		disp('All tests pass!!')
-% 	end 
-% 	disp(sprintf('==============================================================\n'))
+	% Tell the user which test case we are running.
+	disp(sprintf('\n=============================================================='))
+	disp(['Test case running: ' testname])
+	disp(sprintf('==============================================================\n'))
+
+	% Test setup
+	testSetup(porwb, torf, matorimg)
+
+	% Generate the results for the test.
+	generateData(porwb, torf, matorimg);
+
+
+	% Tell the user we have run the test.
+	disp(sprintf('\n=============================================================='))
+	disp(['Test case ' testname ' has been run.'])
+	disp('--------------------------------------------------------------')
+	disp('Verifying test results')
+	disp(sprintf('==============================================================\n'))
+
+	% Compare test results to ground truth.
+	result = verifyMapsUnchanged(porwb, torf, matorimg);
+
+	% Tell the user whether the tests passed.
+	disp(sprintf('\n=============================================================='))
+	if ~result
+		disp('A test has failed!')
+		error(['Test ' testname ' has failed.'])
+	else
+		disp('All tests pass!!')
+	end 
+	disp(sprintf('==============================================================\n'))
 
 	% Teardown method
 	testTearDown(porwb, torf, matorimg)

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -54,7 +54,7 @@ function result=runTest(porwb, torf, matorimg)
 % 		error(['Test ' testname ' has failed.'])
 % 	else
 % 		disp('All tests pass!!')
-% 	end
+% 	end 
 % 	disp(sprintf('==============================================================\n'))
 
 	% Teardown method

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -66,6 +66,7 @@ function testSetup(porwb, torf, matorimg)
 
 	% Move into the test folder and add the path to tests.
 	cd(['/swe/test/data/test_' porwb '_' torf '_' matorimg]);
+	ls;
 	addpath('/swe');
 	addpath('/swe/test');
 

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -30,6 +30,9 @@ function result=runTest(porwb, torf, matorimg)
 	disp(['Test case running: ' testname])
 	disp(sprintf('==============================================================\n'))
 
+	% Test setup
+	testSetup(porwb, torf, matorimg)
+
 	% Generate the results for the test.
 	generateData(porwb, torf, matorimg);
 
@@ -44,7 +47,7 @@ function result=runTest(porwb, torf, matorimg)
 	% Compare test results to ground truth.
 	result = verifyMapsUnchanged(porwb, torf, matorimg);
 
-	%Tell the user whether the tests passed.
+	% Tell the user whether the tests passed.
 	disp(sprintf('\n=============================================================='))
 	if ~result
 		disp('A test has failed!')
@@ -54,10 +57,12 @@ function result=runTest(porwb, torf, matorimg)
 	end
 	disp(sprintf('==============================================================\n'))
 
+	% Teardown method
+	testTearDown(porwb, torf, matorimg)
+
 end
 
-
-function generateData(porwb, torf, matorimg)
+function testSetup(porwb, torf, matorimg)
 
 	% Move into the test folder and add the path to tests.
 	cd(['/swe/test/data/test_' porwb '_' torf '_' matorimg]);
@@ -72,6 +77,16 @@ function generateData(porwb, torf, matorimg)
 	randp('state', seed);
 	randg('state',seed);
 	rande('state',seed);
+
+	% Make a copy of the original xSwE object for future runs.
+	if exist('xSwE.mat')~=0
+		copyfile('xSwE.mat', 'xSwE_orig.mat')
+	end
+
+end
+
+function generateData(porwb, torf, matorimg)
+
 
 	% Load the test design and run it.
 	load('design.mat');
@@ -223,5 +238,18 @@ function mapsEqual = verifyMapsUnchanged(porwb, torf, matorimg)
     % return true if all maps were equal false otherwise.
 
     mapsEqual = ~any(~equalMaps);
+
+end
+
+function testTearDown(porwb, torf, matorimg)
+	
+	% Delete all files from this run.
+	delete('swe_*')
+	delete('SwE*')
+
+	if exist('xSwE.mat')~=0
+		delete('xSwE.mat')
+		rename('xSwE_orig.mat', 'xSwE.mat')
+	end
 
 end


### PR DESCRIPTION
Thanks to explanation given by @cmaumet , I realize that the streaming usage for git lfs on `SwE-Toolbox-Testdata` can be reduced significantly by caching the data downloaded for the `SwE-Toolbox` tests. This minimizes any risk of going over the git lfs data usage (which I have been getting a lot of warning emails about) as the data will not be redownloaded every test.