### PR TITLE
Adding multiple covariate options

### DIFF
--- a/swe_cfg_design.m
+++ b/swe_cfg_design.m
@@ -131,7 +131,7 @@ cov.val     = {{''}};
 cov.help    = {
                'Select the *.mat/*.txt file(s) containing details of your multiple covariates. '
                ''
-               'You will first need to create a *.mat file containing a matrix R or a *.txt file containing the covariates. Each column of R will contain a different covariate. Unless the covariates names are given in a cell array called ''names'' in the MAT-file containing variable R, the covariates will be named R1, R2, R3, ..etc.'
+               'A *.mat file must contain a matrix R, and may optionally contain a cell array called ''names'' with covariate names. A *.txt file can be any file that can be read by Matlab''s IMPORTDATA function, which includes a data-only text file, with spaces, tabs or comma separators. A header row is allowed, and if present will be used to obtain the covariate names. If names for the covariates are not give they will be named R1, R2, R3, ..etc.'
               }';
 cov.filter  = 'mat';
 cov.ufilter = '.*';

--- a/swe_cfg_design.m
+++ b/swe_cfg_design.m
@@ -131,7 +131,7 @@ cov.val     = {{''}};
 cov.help    = {
                'Select the *.mat/*.txt file(s) containing details of your multiple covariates. '
                ''
-               'A *.mat file must contain a matrix R, and may optionally contain a cell array called ''names'' with covariate names. A *.txt file can be any file that can be read by Matlab''s IMPORTDATA function, which includes a data-only text file, with spaces, tabs or comma separators. A header row is allowed, and if present will be used to obtain the covariate names. If names for the covariates are not give they will be named R1, R2, R3, ..etc.'
+               'A *.mat file must contain a matrix R, and may optionally contain a cell array called ''names'' with covariate names. A *.txt file can be any file that can be read by Matlab''s IMPORTDATA function, which includes a data-only text file, with spaces, tabs or comma separators. A header row is allowed, and if present will be used to obtain the covariate names. If names for the covariates are not given they will be named R1, R2, R3, ..etc.'
               }';
 cov.filter  = 'mat';
 cov.ufilter = '.*';

--- a/swe_cfg_design.m
+++ b/swe_cfg_design.m
@@ -96,46 +96,7 @@ cname.name    = 'Name';
 cname.help    = {'Name of the covariate'};
 cname.strtype = 's';
 cname.num     = [1 Inf];
-% ---------------------------------------------------------------------
-% iCFI Interactions
-% ---------------------------------------------------------------------
-iCFI         = cfg_menu;
-iCFI.tag     = 'iCFI';
-iCFI.name    = 'Interactions';
-iCFI.help    = {
-                'For each covariate you have defined, there is an opportunity to create an additional regressor that is the interaction between the covariate and a chosen experimental factor. '
-                ''
-}';
-iCFI.labels = {
-               'None'
-               'With Factor 1'
-               'With Factor 2'
-               'With Factor 3'
-}';
-iCFI.values = {1 2 3 4};
-iCFI.val    = {1};
-% ---------------------------------------------------------------------
-% iCC Centering
-% ---------------------------------------------------------------------
-iCC         = cfg_menu;
-iCC.tag     = 'iCC';
-iCC.name    = 'Centering';
-iCC.help    = {
-               'The appropriate centering option is usually the one that corresponds to the interaction chosen, and ensures that main effects of the interacting factor aren''t affected by the covariate. You are advised to choose this option, unless you have other modelling considerations. '
-               ''
-}';
-iCC.labels = {
-              'Overall mean'
-              'Factor 1 mean'
-              'Factor 2 mean'
-              'Factor 3 mean'
-              'No centering'
-              'User specified value'
-              'As implied by ANCOVA'
-              'GM'
-}';
-iCC.values = {1 2 3 4 5 6 7 8};
-iCC.val    = {5};
+
 % ---------------------------------------------------------------------
 % cov Covariate
 % ---------------------------------------------------------------------
@@ -143,7 +104,6 @@ cov         = cfg_branch;
 cov.tag     = 'cov';
 cov.name    = 'Covariate';
 cov.val     = {c cname };
-%cov.val     = {c cname iCFI iCC };
 cov.help    = {'Add a new covariate to your design.'
                'Please note that no covariates is added per default. Thus, all the model covariates must be added by the user.'
                'Note also that a function called swe_splitCovariate can be used to split time-varying covariates into a cross-sectional component and a longitudinal component. This may be useful to take apart these two different mode of variation'};
@@ -159,7 +119,42 @@ generic.help    = {
                    ''
 }';
 generic.values  = {cov };
-generic.num     = [1 Inf];
+generic.num     = [0 Inf];
+
+%--------------------------------------------------------------------------
+% multi_reg Multiple covariates
+%--------------------------------------------------------------------------
+cov         = cfg_files;
+cov.tag     = 'files';
+cov.name    = 'File(s)';
+cov.val     = {{''}};
+cov.help    = {
+               'Select the *.mat/*.txt file(s) containing details of your multiple covariates. '
+               ''
+               'You will first need to create a *.mat file containing a matrix R or a *.txt file containing the covariates. Each column of R will contain a different covariate. Unless the covariates names are given in a cell array called ''names'' in the MAT-file containing variable R, the covariates will be named R1, R2, R3, ..etc.'
+              }';
+cov.filter  = 'mat';
+cov.ufilter = '.*';
+cov.num     = [0 Inf];
+
+%--------------------------------------------------------------------------
+% multi_cov Covariate
+%--------------------------------------------------------------------------
+multi_cov         = cfg_branch;
+multi_cov.tag     = 'multi_cov';
+multi_cov.name    = 'Covariates';
+multi_cov.val     = {cov};
+multi_cov.help    = {'Add a new set of covariates to your experimental design.'};
+
+%--------------------------------------------------------------------------
+% generic2 Multiple covariates
+%--------------------------------------------------------------------------
+generic2        = cfg_repeat;
+generic2.tag    = 'generic';
+generic2.name   = 'Multiple covariates';
+generic2.help   = {'This option allows for the specification of multiple covariates from TXT/MAT files.'};
+generic2.values = {multi_cov};
+generic2.num    = [0 Inf];
 
 % ---------------------------------------------------------------------
 % tm_none None
@@ -795,7 +790,7 @@ WB.val    = {WB_no};
 design        = cfg_exbranch;
 design.tag    = 'design';
 design.name   = 'Data & Design';
-design.val    = {dir scans type subjects generic masking WB globalc globalm};
+design.val    = {dir scans type subjects generic generic2 masking WB globalc globalm};
 design.help   = {' '
                  'Module of the SwE toolbox allowing the specification of the data and design.'};
 design.prog   = @swe_run_design;

--- a/swe_run_design.m
+++ b/swe_run_design.m
@@ -192,21 +192,30 @@ xC = [];                         %-Struct array to hold raw covariates
 %--------------------------------------------------------------------------
 for m=1:numel(job.multi_cov)
     for n=1:numel(job.multi_cov(m).files)
-        tmp   = load(job.multi_cov(m).files{n});
+        tmp   = importdata(job.multi_cov(m).files{n});
         names = {};
         if isstruct(tmp) % .mat
-            if isfield(tmp,'R')
+            % If it's a manually created structure with field 'R' mandatory
+            % containing matrix and field 'names' optionally containing a
+            % cell array of names.
+            if isfield(tmp,'R') 
                 R = tmp.R;
                 if isfield(tmp,'names')
                     names = tmp.names;
+                end
+            % If it's a structure created by importdata from reading a
+            % table with column headers.
+            elseif isfield(tmp,'data')
+                R = tmp.data;
+                if isfield(tmp,'colheaders')
+                    names = tmp.colheaders;
                 end
             else
                 error(['Variable ''R'' not found in multiple ' ...
                     'covariates file ''%s''.'], job.multi_cov(m).files{n});
             end
-        elseif isnumeric(tmp) % .txt
+        elseif isnumeric(tmp) % .txt file with no column headers.
             R     = tmp;
-            % read names from first line if commented?
         end
         for j=1:size(R,2)
             job.cov(end+1).c   = R(:,j);

--- a/swe_run_design.m
+++ b/swe_run_design.m
@@ -188,6 +188,38 @@ H  = []; Hnames = [];
 B  = []; Bnames = [];
 xC = [];                         %-Struct array to hold raw covariates
 
+%-Multiple covariates
+%--------------------------------------------------------------------------
+for m=1:numel(job.multi_cov)
+    for n=1:numel(job.multi_cov(m).files)
+        tmp   = load(job.multi_cov(m).files{n});
+        names = {};
+        if isstruct(tmp) % .mat
+            if isfield(tmp,'R')
+                R = tmp.R;
+                if isfield(tmp,'names')
+                    names = tmp.names;
+                end
+            else
+                error(['Variable ''R'' not found in multiple ' ...
+                    'covariates file ''%s''.'], job.multi_cov(m).files{n});
+            end
+        elseif isnumeric(tmp) % .txt
+            R     = tmp;
+            % read names from first line if commented?
+        end
+        for j=1:size(R,2)
+            job.cov(end+1).c   = R(:,j);
+            if isempty(names)
+                job.cov(end).cname = sprintf('R%d%s',j);
+            else
+                job.cov(end).cname = names{j};
+            end
+        end
+    end
+end
+
+%-Single covariates
 % Covariate options:
 nc=length(job.cov); % number of covariates
 for i=1:nc


### PR DESCRIPTION
This PR addresses issue #25 by adding options to specify multiple regressors at once, either using a file containing a structure or two files, one containing a matrix and one containing a list of filenames (a previous attempt of this can be found here: #44 ).