### PR TITLE
Bug for group size fixed

### DIFF
--- a/swe_cp.m
+++ b/swe_cp.m
@@ -280,7 +280,7 @@ if isfield(SwE.type,'modified')
         nSubj_g(g) = length(uSubj_g{g});
         uSubj_g_tmp = uSubj_g{g};
         
-        for k = 1:nSubj_g 
+        for k = 1:nSubj_g(g) 
 
              % The number of visits for subject uSubj_g(k)
              vis_g_subj(k) = sum(iSubj_g==uSubj_g_tmp(k));


### PR DESCRIPTION
This PR aims to address a bug reported on the SwE mailing list. The bug occurred on [line 283](https://github.com/NISOx-BDI/SwE-toolbox/blob/master/swe_cp.m#L283) of `swe_cp`.

The reason for this bug was the variable `nSubj_g`. This is the variable which records the number of subjects in each group. E.g. `nSubj_g=[10, 12, 32]` would mean group one had 10 subjects, group 2 had 12 subjects and group 3 had 32 subjects.

The problem here was that the for loop on line 283 was meant to cycle through each subject in each group. I.e. for each group, with group number `g`, it was meant to cycle through `nSubj_g(g)` subjects (carrying on from the example above, for group 1 it should have cycled through 10 subjects, for group 2 it should have cycled through 12 subjects and for group 3 it should have cycled through 32 subjects).

The issue was that the `(g)` subscript was missing and as a result the loop was always trying to cycle through `nSubj_g(1)` subjects. This had not previously been caught as all of the examples in the testing suite have the same number of subjects in each group.

@nicholst , This PR is ready for review, please let me know if you have any feedback/everything here seems correct to you.