### PR TITLE
New release 1.2.11

### DIFF
--- a/swe_contrasts.m
+++ b/swe_contrasts.m
@@ -2,7 +2,7 @@ function [SwE] = swe_contrasts(SwE,Ic)
 % Fills in SwE.xCon and writes con_????.img, ess_????.img and SwE?_????.img
 % FORMAT [SwE] = SwE_contrasts(SwE,Ic)
 %
-% SwE - SwE data structure
+% SwE - SwE data structure 
 % Ic  - indices of xCon to compute
 % Modified version of spm_contrasts adapted for the SwE toolbox
 % By Bryan Guillaume


### PR DESCRIPTION
Hi @nicholst ,

This is a very quick PR to include the following changes:

 - fix: The error message given when no voxels remain after thresholding has been changed as requested in PR #55 .
 - fix: The bug reported concerning `voxfmt` not existing when no voxels survive thresholding has been fixed.
 - dev: A watermark has been added to the design display so that the Design window also displays the version number of the SwE toolbox release used to specify the design.
 - fix: The design matrix latex interpreter has been added into this release as it should have been in `new_release_1.2.10`.

Please let me know if you are happy for me to go ahead and release this as a new version/ if you have any feedback on the changes made. 

This PR is a PR into the branch `NISOx-BDI\new_release_1.2.11`. This branch will be used as the target for the new release. However, if you are okay with me doing so I will also merge this branch into master as well so that the changes made here are also present the next time we make a release based on the master branch (i.e. when we release 2.0.0).