### PR TITLE
Seed reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test/data/*
 test/MOxUnit/*
 # Autosaves
 *.asv
+.*~

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -60,7 +60,7 @@ end
 
 %-Shuffle seed of random number generator
 %--------------------------------------------------------------------------
-if snpm_get_defaults('shuffle_seed')
+if swe_get_defaults('shuffle_seed')
   rng('shuffle');
 end
 

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -58,6 +58,13 @@ catch %#ok<*CTCH>
   SwE.swd = pwd;
 end
 
+%-Shuffle seed of random number generator
+%--------------------------------------------------------------------------
+if snpm_get_defaults('shuffle_seed')
+  rng('shuffle');
+end
+
+
 %-Ensure data are assigned
 %--------------------------------------------------------------------------
 try

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -60,10 +60,7 @@ end
 
 %-Shuffle seed of random number generator
 %--------------------------------------------------------------------------
-if swe_get_defaults('shuffle_seed')
-  rng('shuffle');
-end
-
+swe_seed
 
 %-Ensure data are assigned
 %--------------------------------------------------------------------------

--- a/swe_defaults.m
+++ b/swe_defaults.m
@@ -1,0 +1,24 @@
+%
+% FORMAT swe_defaults
+%_______________________________________________________________________
+%
+% This file is intended to be customised for the site.
+% Individual users can make copies which can be stored in their own
+% matlab subdirectories. If ~/matlab is ahead of the SwE directory
+% in the MATLABPATH, then the users own personal defaults are used.
+%
+% Care must be taken when modifying this file
+%_______________________________________________________________________
+% Based on snpm_defaults.m
+% Thomas Nichols
+% $Id$
+
+global SwEdefs
+
+% If true, shuffles the seed of the random number generator to get 
+% different results every time. Use false, if you want to specify your own 
+% seed, for instance to insure that results can be replicated or when using 
+% a high performance cluster.
+%------------------------------------------------------------------------
+SwEdefs.shuffle_seed = true; 
+

--- a/swe_get_defaults.m
+++ b/swe_get_defaults.m
@@ -1,0 +1,34 @@
+function varargout = swe_get_defaults(defstr, varargin)
+% Get/set the defaults values associated with an identifier
+% FORMAT defval = swe_get_defaults(defstr)
+% Return the defaults value associated with identifier "defstr". 
+% Currently, this is a '.' subscript reference into the global  
+% "defaults" variable defined in swe_defaults.m.
+%
+% FORMAT swe_get_defaults(defstr, defval)
+% Sets the defaults value associated with identifier "defstr". The new
+% defaults value applies immediately to:
+% * new modules in batch jobs
+% * modules in batch jobs that have not been saved yet
+% This value will not be saved for future sessions of SwE. To make
+% persistent changes, edit swe_defaults.m.
+%__________________________________________________________________________
+% Based on swe_get_defaults.m
+% Thomas Nichols
+% $Id$
+
+global SwEdefs;
+if isempty(SwEdefs)
+    swe_defaults;
+end
+
+% % construct subscript reference struct from dot delimited tag string
+% tags = textscan(defstr,'%s', 'delimiter','.');
+% subs = struct('type','.','subs',tags{1}');
+subs = defstr;
+
+if nargin == 1
+    varargout{1} = getfield(SwEdefs, subs);
+else
+    SwEdefs = setfield(SwEdefs, subs, varargin{1});
+end

--- a/swe_seed.m
+++ b/swe_seed.m
@@ -1,0 +1,60 @@
+function swe_seed(varargin)
+% Sets the random number generator seed
+% =========================================================================
+% Randomly or deterministically seed the random number generator
+% =========================================================================
+% FORMAT swe_seed
+% -------------------------------------------------------------------------
+% Randomly seed the random number generator. If SwE default "shuffle_seed"
+% is false no action is taken.
+% =========================================================================
+% FORMAT swe_seed(Seed)
+% -------------------------------------------------------------------------
+% Inputs:
+%   - Seed: Value for random number generator seed.
+% Deterministically seed the random number generator with value Seed.  
+% Useful for creating reproducible random numbers for testing; then make 
+% sure that "shuffle_seed" default is false to prevent re-seeding.
+% =========================================================================
+% T. Nichols
+% $Id$
+
+isOctave = exist('OCTAVE_VERSION','builtin');
+
+if nargin==0
+
+  % Random seeding
+  %----------------------------------------------------------------------
+  if swe_get_defaults('shuffle_seed')
+    if isOctave
+      rand( "state","reset");
+      randn("state","reset");
+      rande("state","reset");
+      randg("state","reset");
+      randp("state","reset");
+    else
+      rng('shuffle');
+    end
+  end
+
+elseif nargin==1
+
+  % Deterministic seeding
+  %----------------------------------------------------------------------
+  Seed=varargin{1};
+  if isOctave
+    rand( "state",Seed);
+    randn("state",Seed);
+    rande("state",Seed);
+    randg("state",Seed);
+    randp("state",Seed);
+  else
+    rng(Seed);
+  end
+
+else
+
+  error('swe_seed: Wrong number of arguments')
+
+end
+

--- a/swe_seed.m
+++ b/swe_seed.m
@@ -49,7 +49,7 @@ elseif nargin==1
     randg("state",Seed);
     randp("state",Seed);
   else
-    rng(Seed);
+    rng(Seed(1));
   end
 
 else

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -20,6 +20,10 @@ function result=runTest(porwb, torf, matorimg)
 	warning('off','Octave:abbreviated-property-match');
 	warning('off','Octave:num-to-str');
 
+	% Disable random number seeding
+	global SwEdefs
+	SwEdefs.shuffle_seed = false;
+
 	% Work out which test we are running.
 	testname = [porwb '_' torf '_' matorimg];
 

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -76,14 +76,9 @@ function testSetup(porwb, torf, matorimg)
     % run managed to get cached.
     testTearDown(porwb, torf, matorimg);
 
-	% Reset all seeds 
-	% (Footnote: In octave these are all different!!).
+	% Set RNG seed to fixed value
 	load('/swe/test/data/seed.mat');
-	rand('state',seed);
-	randn('state', seed);
-	randp('state', seed);
-	randg('state',seed);
-	rande('state',seed);
+	swe_seed(seed)
 
 	% Make a copy of the original xSwE object for future runs.
 	if exist('xSwE.mat')~=0


### PR DESCRIPTION
SwE previously did not seed the random number generator, and this is a problem for Matlab in that identical WB results would be obtained from fresh Matlab sessions. (In Octave the RNG is randomly seeded each session).

This PR resolves this, randomly seeding the RNG by default, but allowing a disabling of the seeding via the `SwEdefs.shuffle_seed` global (important for testing).