### PR TITLE
Incorrect quotes for MATLAB

### DIFF
--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -92,7 +92,7 @@ end
 %-Prevent unnecessary octave warning
 %--------------------------------------------------------------------------
 if isOctave
-   warning ("off", "histc: empty EDGES specified\n"); 
+   warning ('off', 'histc: empty EDGES specified\n'); 
 end
 
 %-Delete files from previous analyses


### PR DESCRIPTION
This line was causing an error to be thrown when our researcher tried to run swe in MATLAB.