### PR TITLE
Set modality consistently

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -13,6 +13,12 @@ function varargout = swe(varargin)
 
 versionNo = '1.2.11';
 
+try
+  Modality = spm_get_defaults('modality');
+catch
+  spm('defaults','FMRI'); % Starting w/out SPM
+end
+
 if nargin == 0
     Action = 'StartUp';
 else

--- a/swe_results_ui.m
+++ b/swe_results_ui.m
@@ -224,7 +224,6 @@ function varargout = swe_results_ui(varargin)
 %__________________________________________________________________________
 % Modified version of spm_results_ui by Bryan Guillaume 
 
-spm('defaults','FMRI')% to avoid trouble with testing
 %-Condition arguments
 %--------------------------------------------------------------------------
 if nargin == 0, Action='setup'; else Action=varargin{1}; end


### PR DESCRIPTION
Modality is now set to FMRI (if not already set), in swe.m.  This is important if swe is directly called, without SPM being opened first.

Done to address issue #74.