### PR TITLE
Add cluster forming threshold to clustere header

### DIFF
--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -627,11 +627,13 @@ if ~isMat
       
     % We also need cluster p value maps here.
     VlP_wb_clusterFWE_pos = swe_create_vol(sprintf('swe_clustere_%cstat_lpFWE-WB_c%02d%s', WB.stat, 1, file_ext), DIM, M,...
-                                           '-log10(clusterFWE-corr. P, +ve)');
+                                           sprintf('-log10(clusterFWE-corr. P, CFT %g, +ve)',...
+						   SwE.WB.clusterInfo.primaryThreshold));
     
     if WB.stat=='T'
       VlP_wb_clusterFWE_neg = swe_create_vol(sprintf('swe_clustere_%cstat_lpFWE-WB_c%02d%s', WB.stat, 2, file_ext), DIM, M,...
-                                             '-log10(clusterFWE-corr. P, -ve)');
+                                             sprintf('-log10(clusterFWE-corr. P, CFT %g, -ve)',...
+						     SwE.WB.clusterInfo.primaryThreshold));
     end
   end
   


### PR DESCRIPTION
The cluster forming threshold is an important parameter that could be lost... in lieu of awkwardly encoding it in the filename, put it in NIFTI description.