### PR TITLE
Specify random number generator to use.

### DIFF
--- a/swe_seed.m
+++ b/swe_seed.m
@@ -33,6 +33,7 @@ if nargin==0
       randg('state','reset');
       randp('state','reset');
     else
+      rng('default');
       rng('shuffle');
     end
   end


### PR DESCRIPTION
This addresses a problem identified by @justbennet on Matlab R2018a in #86.