### PR TITLE
Release SwE Version 2.1.0

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -11,7 +11,7 @@ function varargout = swe(varargin)
 % Written by Bryan Guillaume
 % Version Info:  $Format:%ci$ $Format:%h$
 
-versionNo = '2.0.0';
+versionNo = '2.1.0';
 
 try
   Modality = spm_get_defaults('modality');

--- a/swe_DesRep.m
+++ b/swe_DesRep.m
@@ -719,7 +719,7 @@ str='Statistical analysis: Design'; if ~desmtx, str=[str,' orthogonality']; end
 text(0.5,0.95,str,'Fontsize',FS(14),'Fontweight','Bold',...
     'HorizontalAlignment','center');
 
-ver = '\it Design specified using SwE Version ' + swe('ver'); % When we update to 2.0.0 this should use swe('ver').
+ver = ['\it Design specified using SwE Version ', swe('ver')]; % When we update to 2.0.0 this should use swe('ver').
 text(0.8,0.04,ver,'Fontsize',FS(8),'Fontweight','Bold',...
     'HorizontalAlignment','center', 'Interpreter', 'Tex', 'Color', [1 1 1]*.6);
 

--- a/swe_DesRep.m
+++ b/swe_DesRep.m
@@ -719,7 +719,7 @@ str='Statistical analysis: Design'; if ~desmtx, str=[str,' orthogonality']; end
 text(0.5,0.95,str,'Fontsize',FS(14),'Fontweight','Bold',...
     'HorizontalAlignment','center');
 
-ver = '\it Design specified using SwE Version 1.2.11'; % When we update to 2.0.0 this should use swe('ver').
+ver = '\it Design specified using SwE Version ' + swe('ver'); % When we update to 2.0.0 this should use swe('ver').
 text(0.8,0.04,ver,'Fontsize',FS(8),'Fontweight','Bold',...
     'HorizontalAlignment','center', 'Interpreter', 'Tex', 'Color', [1 1 1]*.6);
 

--- a/swe_checkCompat.m
+++ b/swe_checkCompat.m
@@ -43,7 +43,7 @@ function swe_checkCompat(matVer, tbVer)
     
     % Record earliest compatible versions.
     earliestCompatVer('2.0.0') = '2.0.0';
-    earliestCompatVer('2.0.1') = '2.0.0';
+    earliestCompatVer('2.1.0') = '2.0.0';
  
     % The below line works out the latest compatible version from the
     % earliest compatible versions. This code is now redundant but may be


### PR DESCRIPTION
#### Changes made since previous version

 - enh: The eigenvariates display now works.
 - enh: The code now checks for incompatibilities when loading the `SwE.mat` file. 
 - fix: Random number generator to use is now specified.
 - dev: Identifiers have been added to the headers of all files.
 - enh: Display options are now available for deactivations in a wild bootstrap analysis.
 - dev: Indentation has been reviewed for several of the files.

#### Link to relevant issues

 - Issue #1 
 - Issue #69
 - Issue #86 
 - Issue #89 
 - Issue #92 