### PR TITLE
Travis now points back to master data branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ install:
  - cd SwE-toolbox/test/data
  - if ! [ -d .git ]; then git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files) 
- - git checkout UOflowUpdate
- - travis_retry git reset --hard origin/UOflowUpdate
+ - git checkout master
+ - travis_retry git reset --hard origin/master
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
- - travis_retry git reset --hard origin/UOflowUpdate
+ - travis_retry git reset --hard origin/master
  - cd ../..
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
  - git lfs install  
  # Download data.
  - cd SwE-toolbox/test/data
- - if ! [ -d .git ]; then git clone https://github.com/TomMaullin/SwE-toolbox-testdata.git .; fi
+ - if ! [ -d .git ]; then git clone https://github.com/NISOx-BDI/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files) 
  - git checkout master
  - travis_retry git reset --hard origin/master


### PR DESCRIPTION
This is a quick PR to point the travis tests back to the master branch on the data repository (which now has all updates from the ground truth changes needed for pr #98 ).
