### PR TITLE
Fix for conjunctions

### DIFF
--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -592,7 +592,7 @@ end
 %-Compute & store contrast parameters, contrast/ESS images, & SwE images
 %==========================================================================
 SwE.xCon = xCon;
-alreadyComputed = ~isempty(xCon(Ic).Vspm);
+alreadyComputed = all(~cellfun(@isempty,{xCon(Ic).Vspm}));
 
 if isnumeric(Im)
     SwE  = swe_contrasts(SwE, unique([Ic, Im, IcAdd]));


### PR DESCRIPTION
Fixing small bug in `swe_getSPM.m`, ultimately just relating to a status message display, triggered when using conjunctions.

As it appears conjunctions have never been tested I'm leaving this open in case user finds more bugs.