### PR TITLE
Fix a bug in subfunction swe_resid_corr

### DIFF
--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -2546,7 +2546,7 @@ switch ss
   case 0
     corr = ones(nScan,1);
   case 1
-    if WB.RSwE == 1
+    if restric == 1
       corr  = repmat(sqrt(nScan/(nScan - nBeta + rankCon)),nScan,1); % residual correction (type 1)
     else
       corr  = repmat(sqrt(nScan/(nScan-nBeta)),nScan,1); 


### PR DESCRIPTION
This PR aims to correct a bug in the subfunction swe_resid_corr of swe_cp_WB.  One of the if condition was using a variable (i.e. WB.RSwE) that was not in the scope of the subfunction. This would affect only the analyses using the small sample correction of type 1 and would result in an error message. 

The fix seems strightforward as it consists to replace the "out-of-scope" variable (i.e. WB.RSwE) by its corresponding variable that is in the scope of the subfunction (i.e. restric).