### PR TITLE
Fix a a bug in the computation of TFCE scores for F-contrasts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ install:
  - git lfs install  
  # Download data.
  - cd SwE-toolbox/test/data
- - if ! [ -d .git ]; then git clone https://github.com/NISOx-BDI/SwE-toolbox-testdata.git .; fi
+ - if ! [ -d .git ]; then git clone https://github.com/BryanGuillaume/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files) 
- - git checkout master
- - travis_retry git reset --hard origin/master
+ - git checkout changeGT_test_wb_tfce_f_img
+ - travis_retry git reset --hard origin/changeGT_test_wb_tfce_f_img
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
- - travis_retry git reset --hard origin/master
+ - travis_retry git reset --hard origin/changeGT_test_wb_tfce_f_img
  - cd ../..
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ install:
  - git lfs install  
  # Download data.
  - cd SwE-toolbox/test/data
- - if ! [ -d .git ]; then git clone https://github.com/BryanGuillaume/SwE-toolbox-testdata.git .; fi
+ - if ! [ -d .git ]; then git clone https://github.com/NISOx-BDI/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files) 
- - git checkout changeGT_test_wb_tfce_f_img
- - travis_retry git reset --hard origin/changeGT_test_wb_tfce_f_img
+ - git checkout master
+ - travis_retry git reset --hard origin/master
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
- - travis_retry git reset --hard origin/changeGT_test_wb_tfce_f_img
+ - travis_retry git reset --hard origin/master
  - cd ../..
 jobs:
   include:

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1729,8 +1729,18 @@ for b = 1:WB.nB
 	% Current XYZ indices
 	currXYZ = XYZ(1:3, index);
 	  
-	  % T stat from this bootstrap
-	  scorevol(sub2ind(DIM,currXYZ(1,:),currXYZ(2,:),currXYZ(3,:))) = hyptest.positive.conScore;
+        % T test already converted to Z
+        if strcmp(WB.stat, 'T')
+          scorevol(sub2ind(DIM,currXYZ(1,:),currXYZ(2,:),currXYZ(3,:))) = hyptest.positive.conScore;
+        % F test needs to be converted to Z
+        else
+          % Get score volume from p values
+          sv = -swe_invNcdf(hyptest.positive.p);
+          % remove NaNs
+          sv(isnan(scorevol))=0;
+          % Save as scorevol
+          scorevol(sub2ind(DIM,currXYZ(1,:),currXYZ(2,:),currXYZ(3,:))) = sv;
+        end
 	
       end
       


### PR DESCRIPTION
This PR aims to correct the bug reported in issue #112. In brief, the bootstraped TFCE scores for F-contrasts were computed based on X-scores instead of Z-scores. This PR simply replace the X-scores by Z-scores.