### PR TITLE
[WIP] Improve swe_update by adding the possibility to use webread instead of urlread if the latter fails

### DIFF
--- a/swe_update.m
+++ b/swe_update.m
@@ -21,7 +21,11 @@ function swe_update()
     
     % Error if we couldn't contact github.
     if ~stat 
-      error('Can''t contact GitHub');
+      try 
+        s  = webread(url);
+      catch
+        error('Can''t contact GitHub');
+      end
     end
     
     % Look for latest swe version number.


### PR DESCRIPTION
This PR aims to adress the bug reported in issue #111. In brief, the function `urlread` used in `swe_update` may systematically fail to contact GitHub for some users. If this happens, we now try again to contact GitHub by using the function `webread` instead.