### PR TITLE
Fix a bug in the cluster-wise WB for negative effects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ install:
  - git lfs install  
  # Download data.
  - cd SwE-toolbox/test/data
- - if ! [ -d .git ]; then git clone https://github.com/NISOx-BDI/SwE-toolbox-testdata.git .; fi
+ - if ! [ -d .git ]; then git clone https://github.com/BryanGuillaume/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files) 
- - git checkout master
- - travis_retry git reset --hard origin/master
+ - git checkout changeGT_test_wb_clus_t_img
+ - travis_retry git reset --hard origin/changeGT_test_wb_clus_t_img
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
- - travis_retry git reset --hard origin/master
+ - travis_retry git reset --hard origin/changeGT_test_wb_clus_t_img
  - cd ../..
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ install:
  - git lfs install  
  # Download data.
  - cd SwE-toolbox/test/data
- - if ! [ -d .git ]; then git clone https://github.com/BryanGuillaume/SwE-toolbox-testdata.git .; fi
+ - if ! [ -d .git ]; then git clone https://github.com/NISOx-BDI/SwE-toolbox-testdata.git .; fi
  # Delete any previous changes (retry because lfs might download files) 
- - git checkout changeGT_test_wb_clus_t_img
- - travis_retry git reset --hard origin/changeGT_test_wb_clus_t_img
+ - git checkout master
+ - travis_retry git reset --hard origin/master
  # A second time to allow for 3 more retries as "--retry 9" does not seem to be
  # taken into account by Travis CI
- - travis_retry git reset --hard origin/changeGT_test_wb_clus_t_img
+ - travis_retry git reset --hard origin/master
  - cd ../..
 jobs:
   include:

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1711,6 +1711,9 @@ for b = 1:WB.nB
       if (WB.clusterWise == 1)
         hyptest=swe_hyptest(SwE, score, blksz, cCovBc, Cov_vis, dofMat);
         activatedVoxels(index) = hyptest.positive.activatedVoxels;
+        if (WB.stat == 'T')
+          activatedVoxelsNeg(index) = hyptest.negative.activatedVoxels;
+        end
         clear cCovBc
       end
       uncP(index) = uncP(index) + (score >= originalScore(index));


### PR DESCRIPTION
This PR is a work in progress. It aims to correct issue #116, where the results of the cluster-wise WB for negative effects seemed systematicaly empty. The first reason for this is that the surviving voxels for negative effects had never been computed for each bootstrap (only for the original analysis), yielding maximum bootstraped cluster sizes of 0 for each bootstrap. This has now been fixed by recording correctly the surviving voxels at each bootstrap. The second reason why the results appeared empty was that the result image contained only nan or a single float value (the minimum WB p-value). SPM or FSLeyes does not seem to render these kind of images. This point has not been handled yet.
