### PR TITLE
result display bug fixes and minor enhancements 

### DIFF
--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -288,7 +288,22 @@ end
 
 %-Get contrasts
 %--------------------------------------------------------------------------
-try xCon = SwE.xCon; catch, xCon = {}; end
+try
+  xCon = SwE.xCon; 
+catch
+  if isfield(SwE, 'WB') && ~exist('OCTAVE_VERSION','builtin')
+    SwE = swe_contrasts_WB(SwE);
+    % save SwE with xCon appended to it. This is important for future call of swe_getSPM for a specific Ic
+    if spm_check_version('matlab','7') >=0
+      save('SwE.mat', 'SwE', '-V6');
+    else
+      save('SwE.mat', 'SwE');
+    end
+    xCon = SwE.xCon;    
+  else
+    xCon = {};
+  end
+end
 
 try
     Ic        = xSwE.Ic;
@@ -301,11 +316,8 @@ catch
     % If we're in octave, assume we already have a contrast.
     elseif exist('OCTAVE_VERSION','builtin')
         Ic = 1;
-        xCon = SwE.xCon;
     % If we're doing WB, we already have a contrast. We just need to record it.
     else
-        SwE = swe_contrasts_WB(SwE);
-        xCon = SwE.xCon;
         if numel(xCon) == 2
             Ic = spm_input('Contrast Type','+1','b','Activation|Deactivation',[1,2],1);
         else

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -1062,7 +1062,7 @@ if ~isMat
   end
   if isempty(Q)
       fprintf('\n');                                                      %-#
-      warning('SwE:NoVoxels','No voxels survive thresholding at p=%4.2f',pm);
+      warning('SwE:NoVoxels','No voxels survive thresholding');
   end
   
   % If we are doing clusterwise ask for threshold.
@@ -1163,7 +1163,7 @@ if ~isMat
           XYZ   = XYZ(:,Q);
           if isempty(Q)
               fprintf('\n');                                                  %-#
-              warning('SwE:NoVoxels','No voxels survive masking at p=%4.2f',pm);
+              warning('SwE:NoVoxels','No voxels survive cluster extent threshoding');
           end
           
       else

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -1278,11 +1278,23 @@ if isfield(SwE, 'WB')
     xSwE.Ps = Ps;
     
     % 95% percentiles
-    maxScore = sort(SwE.WB.maxScore);
+    if Ic == 1
+      maxScore = sort(SwE.WB.maxScore);
+    elseif Ic == 2
+      maxScore = sort(-SwE.WB.minScore);
+    else
+      error("Unknown contrast");
+    end
     xSwE.Pfv = maxScore(ceil(0.95*(xSwE.nB+1))); % Voxelwise FWE P 
     if SwE.WB.clusterWise
+      if Ic == 1
         maxClusterSize = sort(SwE.WB.clusterInfo.maxClusterSize);
-        xSwE.Pfc = maxClusterSize(ceil(0.95*(xSwE.nB+1))); % Clusterwise FWE P 
+      elseif Ic == 2
+        maxClusterSize = sort(SwE.WB.clusterInfo.maxClusterSizeNeg);
+      else
+        error("Unknown contrast");
+      end
+      xSwE.Pfc = maxClusterSize(ceil(0.95*(xSwE.nB+1))); % Clusterwise FWE P      
     end
     
     % edf

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -422,136 +422,120 @@ end
 % end % if nc>1...
 SwE.xCon = xCon;
 
-%-Apply masking (if we are doing WB this has already been done).
+%-Apply masking
 %--------------------------------------------------------------------------
-if ~isfield(SwE, 'WB')
-    try
-        Mask = ~isempty(xSwE.Im) * (isnumeric(xSwE.Im) + 2*iscellstr(xSwE.Im));
-    catch
-        % Mask = spm_input('mask with other contrast(s)','+1','y/n',[1,0],2);
-        if isMat
-          Mask = 0;
-        else
-          Mask = spm_input('apply masking','+1','b','none|contrast|image',[0,1,2],1);
-        end
-    end
-    if Mask == 1
+try
+  Mask = ~isempty(xSwE.Im) * (isnumeric(xSwE.Im) + 2*iscellstr(xSwE.Im));
+catch
+  % Mask = spm_input('mask with other contrast(s)','+1','y/n',[1,0],2);
+  if isMat
+    % no masking optionfor mat format
+    Mask = 0;
+  elseif isfield(SwE, 'WB')
+    % for now, the contrast option  is not suggested because there is only the current contrast available
+    % in the WB and it cannot be fetched fron the contrast manager like for parametric analysis.
+    Mask = spm_input('apply masking','+1','b','none|image',[0,2],1);
+  else
+    Mask = spm_input('apply masking','+1','b','none|contrast|image',[0,1,2],1);
+  end
+end
+if Mask == 1
 
-        %-Get contrasts for masking
-        %----------------------------------------------------------------------
-        try
-            Im = xSwE.Im;
-        catch
-            [Im,xCon] = swe_conman(SwE,'T&F',-Inf,...
-                'Select contrasts for masking...',' for masking',1);
-        end
-
-        %-Threshold for mask (uncorrected p-value)
-        %----------------------------------------------------------------------
-        try
-            pm = xSwE.pm;
-        catch
-            pm = spm_input('uncorrected mask p-value','+1','r',0.05,1,[0,1]);
-        end
-
-        %-Inclusive or exclusive masking
-        %----------------------------------------------------------------------
-        try
-            Ex = xSwE.Ex;
-        catch
-            Ex = spm_input('nature of mask','+1','b','inclusive|exclusive',[0,1],1);
-        end
-
-    elseif Mask == 2
-
-        %-Get mask images
-        %----------------------------------------------------------------------
-        try
-            Im = xSwE.Im;
-        catch
-          if isMat
-            Im = cellstr(spm_select([1 Inf],'mat','Select mask image(s)'));
-          else
-            Im = cellstr(spm_select([1 Inf],'image','Select mask image(s)'));
-          end
-        end
-
-        %-Inclusive or exclusive masking
-        %----------------------------------------------------------------------
-        try
-            Ex = xSwE.Ex;
-        catch
-            Ex = spm_input('nature of mask','+1','b','inclusive|exclusive',[0,1],1);
-        end
-
-        pm = [];
-
-    else
-        Im = [];
-        pm = [];
-        Ex = [];
-    end
-
-
-    %-Create/Get title string for comparison
-    %--------------------------------------------------------------------------
-    if isMat
-      titlestr = xCon(Ic).name;
-    else
-      if nc == 1
-          str  = xCon(Ic).name;
-      else
-          str  = [sprintf('contrasts {%d',Ic(1)),sprintf(',%d',Ic(2:end)),'}'];
-          if n == nc
-              str = [str ' (global null)'];
-          elseif n == 1
-              str = [str ' (conj. null)'];
-          else
-              str = [str sprintf(' (Ha: k>=%d)',(nc-n)+1)];
-          end
-      end
-      if Ex
-          mstr = 'masked [excl.] by';
-      else
-          mstr = 'masked [incl.] by';
-      end
-      if isnumeric(Im)
-          if length(Im) == 1
-              str = sprintf('%s (%s %s at p=%g)',str,mstr,xCon(Im).name,pm);
-          elseif ~isempty(Im)
-              str = [sprintf('%s (%s {%d',str,mstr,Im(1)),...
-                  sprintf(',%d',Im(2:end)),...
-                  sprintf('} at p=%g)',pm)];
-          end
-      elseif iscellstr(Im) && numel(Im) > 0
-          [pf,nf,ef] = spm_fileparts(Im{1});
-          str  = sprintf('%s (%s %s',str,mstr,[nf ef]);
-          for i=2:numel(Im)
-              [pf,nf,ef] = spm_fileparts(Im{i});
-              str =[str sprintf(', %s',[nf ef])];
-          end
-          str = [str ')'];
-      end
-    end
-    
-else % ~isfield(SwE, 'WB')
-
-% Ask for a contrast name.
-  if ~isMat
-    if nc == 1
-      str  = xCon(Ic).name;
-    else
-      str  = [sprintf('contrasts {%d',Ic(1)),sprintf(',%d',Ic(2:end)),'}'];
-    end
-      
-    % We have no recorded masks as masking was performed elsewhere for WB,
-    % so here we set this to an empty/non-numeric value.
-    Im = [];
-    pm = [];
-    Ex = [];
+  %-Get contrasts for masking
+  %----------------------------------------------------------------------
+  try
+    Im = xSwE.Im;
+  catch
+    [Im,xCon] = swe_conman(SwE,'T&F',-Inf,...
+      'Select contrasts for masking...',' for masking',1);
   end
 
-end % ~isfield(SwE, 'WB')
+  %-Threshold for mask (uncorrected p-value)
+  %----------------------------------------------------------------------
+  try
+   pm = xSwE.pm;
+  catch
+    pm = spm_input('uncorrected mask p-value','+1','r',0.05,1,[0,1]);
+  end
+
+  %-Inclusive or exclusive masking
+  %----------------------------------------------------------------------
+  try
+    Ex = xSwE.Ex;
+  catch
+    Ex = spm_input('nature of mask','+1','b','inclusive|exclusive',[0,1],1);
+  end
+
+elseif Mask == 2
+
+  %-Get mask images
+  %----------------------------------------------------------------------
+  try
+    Im = xSwE.Im;
+  catch
+    if isMat
+      Im = cellstr(spm_select([1 Inf],'mat','Select mask image(s)'));
+    else
+      Im = cellstr(spm_select([1 Inf],'image','Select mask image(s)'));
+    end
+  end
+
+  %-Inclusive or exclusive masking
+  %----------------------------------------------------------------------
+  try
+    Ex = xSwE.Ex;
+  catch
+    Ex = spm_input('nature of mask','+1','b','inclusive|exclusive',[0,1],1);
+  end
+
+  pm = [];
+
+else
+  Im = [];
+  pm = [];
+  Ex = [];
+end
+
+%-Create/Get title string for comparison
+%--------------------------------------------------------------------------
+if isMat
+  titlestr = xCon(Ic).name;
+else
+  if nc == 1
+    str  = xCon(Ic).name;
+  else
+    str  = [sprintf('contrasts {%d',Ic(1)),sprintf(',%d',Ic(2:end)),'}'];
+    if n == nc
+      str = [str ' (global null)'];
+    elseif n == 1
+      str = [str ' (conj. null)'];
+    else
+      str = [str sprintf(' (Ha: k>=%d)',(nc-n)+1)];
+    end
+  end
+  if Ex
+    mstr = 'masked [excl.] by';
+  else
+    mstr = 'masked [incl.] by';
+  end
+  if isnumeric(Im)
+    if length(Im) == 1
+      str = sprintf('%s (%s %s at p=%g)',str,mstr,xCon(Im).name,pm);
+    elseif ~isempty(Im)
+      str = [sprintf('%s (%s {%d',str,mstr,Im(1)),...
+        sprintf(',%d',Im(2:end)),...
+        sprintf('} at p=%g)',pm)];
+    end
+  elseif iscellstr(Im) && numel(Im) > 0
+    [pf,nf,ef] = spm_fileparts(Im{1});
+    str  = sprintf('%s (%s %s',str,mstr,[nf ef]);
+    for i=2:numel(Im)
+      [pf,nf,ef] = spm_fileparts(Im{i});
+      str =[str sprintf(', %s',[nf ef])];
+    end
+    str = [str ')'];
+  end
+end
 
 if ~isMat
   try

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -1141,8 +1141,6 @@ if ~isMat
               % We then look for the size of the clusters with this p value
               % We do this by first getting this index of clusters with
               % this p value.
-              A = spm_clusters(XYZ);
-
               else
                 error("unknown contrast");
               end

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -533,10 +533,11 @@ if ~isfield(SwE, 'WB')
           str = [str ')'];
       end
     end
-end
+    
+else % ~isfield(SwE, 'WB')
 
 % Ask for a contrast name.
-if ~isMat
+  if ~isMat
     if nc == 1
       str  = xCon(Ic).name;
     else
@@ -556,7 +557,9 @@ if ~isMat
     Im = [];
     pm = [];
     Ex = [];
-end
+  end
+
+end % ~isfield(SwE, 'WB')
 
 if ~isMat
     % Ask whether to do additional voxelwise or clusterwise inference.

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -432,9 +432,10 @@ catch
     % no masking optionfor mat format
     Mask = 0;
   elseif isfield(SwE, 'WB')
-    % for now, the contrast option  is not suggested because there is only the current contrast available
-    % in the WB and it cannot be fetched fron the contrast manager like for parametric analysis.
-    Mask = spm_input('apply masking','+1','b','none|image',[0,2],1);
+    % for now, the post-hoc masking is disabled for the WB
+    % It may be added later.
+    Mask = 0;
+    % Mask = spm_input('apply masking','+1','b','none|image',[0,2],1);
   else
     Mask = spm_input('apply masking','+1','b','none|contrast|image',[0,1,2],1);
   end

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -543,14 +543,6 @@ else % ~isfield(SwE, 'WB')
     else
       str  = [sprintf('contrasts {%d',Ic(1)),sprintf(',%d',Ic(2:end)),'}'];
     end
-    try
-      titlestr = xSwE.title;
-      if isempty(titlestr)
-          titlestr = str;
-      end
-    catch
-      titlestr = spm_input('title for comparison','+1','s',str);
-    end
       
     % We have no recorded masks as masking was performed elsewhere for WB,
     % so here we set this to an empty/non-numeric value.
@@ -560,6 +552,17 @@ else % ~isfield(SwE, 'WB')
   end
 
 end % ~isfield(SwE, 'WB')
+
+if ~isMat
+  try
+    titlestr = xSwE.title;
+    if isempty(titlestr)
+        titlestr = str;
+    end
+  catch
+    titlestr = spm_input('title for comparison','+1','s',str);
+  end
+end
 
 if ~isMat
     % Ask whether to do additional voxelwise or clusterwise inference.

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -1120,6 +1120,8 @@ if ~isMat
                   ind = ( A==clusIndices(i) );
                   ps_fwe(ind) = sum( SwE.WB.clusterInfo.maxClusterSizeNeg >= sum(ind) ) / (SwE.WB.nB + 1);
                 end
+              else
+                  error("unknown contrast");
               end
 
               % select only the voxels surviving the FWER threshold
@@ -1141,9 +1143,6 @@ if ~isMat
               % We then look for the size of the clusters with this p value
               % We do this by first getting this index of clusters with
               % this p value.
-              else
-                error("unknown contrast");
-              end
 
               clusIndices = unique(A(ps_fwe==pofclus));
               


### PR DESCRIPTION
This PR mainly aims to correct a series of bugs in swe_getSPM that were affecting the display of results. They are listed below:

1. It corrects the bug reported in issue #103, where the pos-hoc masking for parametric test was not working anymore. This was due to the fact that a piece of code only dedicated to the WB was also systematically visited by parametric analyses. This was fixed by the use of an if-else condition  (see @@ -422,140 +434,131 @@ in swe_getSPM.m). 
2. It corrects a bug related to issue #122, where the deactivation results for clusterwise WB seemed erroneous. One of the reason for this was that the code was only considering the voxels surviving the positive contrast thresholding and hence, when starting a display of deactivation results, no voxel would survive (see case 2 in issue #122). The latter was fixed by appropriately selecting the voxel surviving the deactivation thresholding (see @@ -978,8 +979,13 @@).
3. It corrects another bug related to issue #122, where the 95th percentiles of maximum scores and maximum cluster sizes for negative t-contrasts was computed as those of the positive t-contrasts. See the modification at @@ -1258,11 +1287,23 @@ in  swe_getSPM.m
4. It corrects a bug in the UI of the results where clicking on some buttons in the **Contrasts** menu would crash the toolbox (see notably issue #107) or yield some weird result display as observed in issue #122. This behaviour was actually due to the fact that the variable SwE had never been saved after the contrast information had been appended to it. This has been fixed by saving it just after calling `SwE = swe_contrasts_WB(SwE);` (see @@ -288,7 +288,22 @@ and @@ -301,11 +316,8 @@). It is worth noting that this simple code modification has solved many missbehaviours that were observed, but it is dificult to see if it corrected them all appropriately. Some thorough checking might be needed.

This PR do also a bit of minor enhancements:

1. Modify some text printed in the matlab console (see @@ -1068,7 +1074,7 @@, @@ -1143,7 +1172,7 @@)
2. Fix some typo (see @@ -961,7 +962,7 @@)
3. Start implementing the post-hoc masking for WB. Nevertheless, the feature has been currently disabled and will be finished later in another PR when more urgent task will be done.

While this PR correct many bugs in swe_getSPM.m, I am pretty sure that there might be more issues (mainly enhancement) with the results display that should be fixed. 