### PR TITLE
Release SwE Version 2.1.1

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -11,7 +11,7 @@ function varargout = swe(varargin)
 % Written by Bryan Guillaume
 % Version Info:  $Format:%ci$ $Format:%h$
 
-versionNo = '2.1.0';
+versionNo = '2.1.1';
 
 try
   Modality = spm_get_defaults('modality');

--- a/swe_checkCompat.m
+++ b/swe_checkCompat.m
@@ -44,6 +44,7 @@ function swe_checkCompat(matVer, tbVer)
     % Record earliest compatible versions.
     earliestCompatVer('2.0.0') = '2.0.0';
     earliestCompatVer('2.1.0') = '2.0.0';
+    earliestCompatVer('2.1.1') = '2.0.0';
  
     % The below line works out the latest compatible version from the
     % earliest compatible versions. This code is now redundant but may be

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1740,7 +1740,7 @@ for b = 1:WB.nB
           % Get score volume from p values
           sv = -swe_invNcdf(hyptest.positive.p);
           % remove NaNs
-          sv(isnan(scorevol))=0;
+          sv(isnan(sv))=0;
           % Save as scorevol
           scorevol(sub2ind(DIM,currXYZ(1,:),currXYZ(2,:),currXYZ(3,:))) = sv;
         end


### PR DESCRIPTION
### Changes made since the previous version

- fix: Handle correctly the case `dof_type = 0` for Wild Bootstrap
- fix: Make the new version of the `SwE` scan selection dialogue compatible with `SPM8`
- fix: Fix a status message display for conjunctions
- fix: Fix a bug in subfunction swe_resid_corr for `dof_type = 1` (before, it would throw an error)
- fix: The subfunction swe_hyptest sets now the p-value of `F-Score <= 0` to 1 
- fix: The bootstrapped TFCE scores for F-contrasts are now computed based on Z-scores instead of X-scores 
- fix: Compute correctly the surviving voxels of each bootstrap of the cluster-wise WB for negative effects
- fix: Fix the post-hoc masking for parametric tests which was not masking any voxels anymore
- fix: Fix the results display of clusterwise Wild Bootstrap for negative contrasts which would sometimes use the voxels surviving the activation (i.e. positive contrast) 
- fix: Display correctly the 95th percentiles of maximum scores and maximum cluster sizes for negative t-contrasts (before, those of the positive t-contrasts were displayed)
- fix: Fix some errors in the `Contrasts` menu in the display window (before, clicking on some buttons in this menu would crash the toolbox)
- enh: save the `xCon` field in `SwE.mat` for Wild Bootstrap analyses
- enh: Prevent some Z-scores to be infinite
- enh: Improve the function `swe_update` by adding the possibility to use `webread` instead of `urlread` if the latter fails to fetch the most recent release version
- enh: Fix some typo 


### Link to relevant issues

- Issue #99
- Issue #103
- Issue #107
- Issue #111
- Issue #112
- Issue #116
- Issue #122