### PR TITLE
Modify the thresholding and the reporting of WB results

### DIFF
--- a/swe_checkCompat.m
+++ b/swe_checkCompat.m
@@ -86,7 +86,7 @@ function lcv = latComVer(ecv)
             if ~isKey(lcv, ecv(ver))
                 lcv(ecv(ver)) = ver;
             else
-                if vercheck(lcv(ecv(ver)), ver, '<=')
+                if swe_compareVersions(lcv(ecv(ver)), ver, '<=')
                     lcv(ecv(ver)) = ver;
                 end
             end
@@ -102,35 +102,4 @@ function lcv = latComVer(ecv)
         end
     end
     
-end
-
-% Perform <=, <, >, >= on version numbers.
-function vcheck = vercheck(ver1, ver2, flag)
-
-    % Split version number into parts.
-    ver1 = strsplit(ver1, '.');
-    ver2 = strsplit(ver2, '.');
-    
-    % Work out base for comparison.
-    base = max(cellfun(@(a) str2num(a), {ver1{:} ver2{:}})) + 1;
-    
-    % Convert to num.
-    ver1 = cellfun(@(a) str2num(a), {ver1{:}});
-    ver2 = cellfun(@(a) str2num(a), {ver2{:}});
-    
-    % Make into number in base `base`
-    ver1 = ver1(1)*base^2 + ver1(2)*base^1 + ver1(3)*base^0;
-    ver2 = ver2(1)*base^2 + ver2(2)*base^1 + ver2(3)*base^0;
-    
-    if strcmp(flag, '<=')
-        vcheck = (ver1 <= ver2);
-    elseif strcmp(flag, '<')
-        vcheck = (ver1 < ver2);
-    elseif strcmp(flag, '>')
-        vcheck = (ver1 > ver2);
-    elseif strcmp(flag, '>=')
-        vcheck = (ver1 >= ver2);
-    else
-        error('unknown flag')
-    end
 end

--- a/swe_compareVersions.m
+++ b/swe_compareVersions.m
@@ -1,0 +1,42 @@
+function result = swe_compareVersions(ver1, ver2, comparisonOperator)
+% Compare two version number of the type 'x.x.x'
+% =========================================================================
+% FORMAT: result = swe_compareVersions(ver1, ver2, comparisonOperator)
+% -------------------------------------------------------------------------
+% Inputs: 
+%   - ver1: first version number of the type 'x.x.x'
+%   - ver2: second version number of the type 'x.x.x'
+%   - comparisonOperator: comparison operator ('<', '<=', '==', '>=' or '>')
+% =========================================================================
+% Author: Bryan Guillaume & Tom Maullin (05/07/2019)
+% Version Info:  $Format:%ci$ $Format:%h$
+  
+  % Split version number into parts.
+  ver1 = strsplit(ver1, '.');
+  ver2 = strsplit(ver2, '.');
+  
+  % Work out base for comparison.
+  base = max(cellfun(@(a) str2num(a), {ver1{:} ver2{:}})) + 1;
+  
+  % Convert to num.
+  ver1 = cellfun(@(a) str2num(a), {ver1{:}});
+  ver2 = cellfun(@(a) str2num(a), {ver2{:}});
+  
+  % Make into number in base `base`
+  ver1 = ver1(1)*base^2 + ver1(2)*base^1 + ver1(3)*base^0;
+  ver2 = ver2(1)*base^2 + ver2(2)*base^1 + ver2(3)*base^0;
+  
+  if strcmp(comparisonOperator, '<=')
+    result = (ver1 <= ver2);
+  elseif strcmp(comparisonOperator, '<')
+    result = (ver1 < ver2);
+  elseif strcmp(comparisonOperator, '==')
+    result = (ver1 == ver2);
+  elseif strcmp(comparisonOperator, '>')
+    result = (ver1 > ver2);
+  elseif strcmp(comparisonOperator, '>=')
+    result = (ver1 >= ver2);
+  else
+    error('unknown comparison operator')
+  end
+end

--- a/swe_contrasts_WB.m
+++ b/swe_contrasts_WB.m
@@ -65,7 +65,7 @@ function [SwE] = swe_contrasts_WB(SwE)
     % Add the SwE volumes.
     %----------------------------------------------------------------------
     DxCon.Vspm = spm_vol(sprintf('swe_vox_%c%cstat_c%.2d%s', eSTAT, STAT, 1, file_ext));
-    DxCon.VspmUncP = spm_vol(sprintf('swe_vox_%cstat_lp_c%.2d%s', STAT, 1, file_ext));
+    DxCon.VspmUncP = spm_vol(sprintf('swe_vox_%cstat_lp%s_c%.2d%s', STAT, wbstring,1, file_ext));
     DxCon.VspmFDRP = spm_vol(sprintf('swe_vox_%cstat_lpFDR%s_c%.2d%s', STAT, wbstring, 1, file_ext));
     DxCon.VspmFWEP = spm_vol(sprintf('swe_vox_%cstat_lpFWE%s_c%.2d%s', STAT, wbstring, 1, file_ext));
     if isfield(SwE,'WB')
@@ -94,7 +94,7 @@ function [SwE] = swe_contrasts_WB(SwE)
         DxCon = spm_FcUtil('Set', 'Contrast 2: Deactivation', STAT, 'c', -c', X);
         
         DxCon.Vspm = spm_vol(sprintf('swe_vox_%c%cstat_c%.2d%s', eSTAT, STAT, 2, file_ext));
-        DxCon.VspmUncP = spm_vol(sprintf('swe_vox_%cstat_lp_c%.2d%s', STAT, 2, file_ext));
+        DxCon.VspmUncP = spm_vol(sprintf('swe_vox_%cstat_lp%s_c%.2d%s', STAT, wbstring, 2, file_ext));
         DxCon.VspmFDRP = spm_vol(sprintf('swe_vox_%cstat_lpFDR%s_c%.2d%s', STAT, wbstring, 2, file_ext));
         DxCon.VspmFWEP = spm_vol(sprintf('swe_vox_%cstat_lpFWE%s_c%.2d%s', STAT, wbstring, 2, file_ext));
         if isfield(SwE,'WB')

--- a/swe_contrasts_WB.m
+++ b/swe_contrasts_WB.m
@@ -65,7 +65,7 @@ function [SwE] = swe_contrasts_WB(SwE)
     % Add the SwE volumes.
     %----------------------------------------------------------------------
     DxCon.Vspm = spm_vol(sprintf('swe_vox_%c%cstat_c%.2d%s', eSTAT, STAT, 1, file_ext));
-    DxCon.VspmUncP = spm_vol(sprintf('swe_vox_%cstat_lp%s_c%.2d%s', STAT, wbstring,1, file_ext));
+    DxCon.VspmUncP = spm_vol(sprintf('swe_vox_%cstat_lp%s_c%.2d%s', STAT, wbstring, 1, file_ext));
     DxCon.VspmFDRP = spm_vol(sprintf('swe_vox_%cstat_lpFDR%s_c%.2d%s', STAT, wbstring, 1, file_ext));
     DxCon.VspmFWEP = spm_vol(sprintf('swe_vox_%cstat_lpFWE%s_c%.2d%s', STAT, wbstring, 1, file_ext));
     if isfield(SwE,'WB')

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1942,10 +1942,16 @@ SwE.WB.maxScore = maxScore;
 if (WB.clusterWise == 1)
     SwE.WB.clusterInfo.maxClusterSize = maxClusterSize;
 end
+if isfield(SwE.WB, 'TFCE')
+  SwE.WB.TFCE.maxTFCEScore = maxTFCEScore;
+end
 if (WB.stat == 'T')
     SwE.WB.minScore = minScore;
     if (WB.clusterWise == 1)
         SwE.WB.clusterInfo.maxClusterSizeNeg = maxClusterSizeNeg;
+    end
+    if isfield(SwE.WB, 'TFCE')
+        SwE.WB.TFCE.maxTFCEScore_neg = maxTFCEScore_neg;
     end
 end
 

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -156,6 +156,9 @@ for i = 1:length(files)
   end
 end
 
+% Tolerance for comparing real numbers
+tol = 1e-4;
+
 %==========================================================================
 % - A N A L Y S I S   P R E L I M I N A R I E S
 %==========================================================================
@@ -1716,7 +1719,7 @@ for b = 1:WB.nB
         end
         clear cCovBc
       end
-      uncP(index) = uncP(index) + (score >= originalScore(index));
+      uncP(index) = uncP(index) + (score > originalScore(index) - tol);
           
       maxScore(b+1) = max(maxScore(b+1), max(score));
       if (SwE.WB.stat == 'T')
@@ -1765,15 +1768,15 @@ for b = 1:WB.nB
       end
       
       % Sum how many voxels are lower than the original parametric tfce.
-      tfce_uncP = tfce_uncP + (par_tfce<=tfce);
+      tfce_uncP = tfce_uncP + (par_tfce  - tol < tfce);
       if SwE.WB.stat == 'T'
-	tfce_uncP_neg = tfce_uncP_neg + (par_tfce_neg<=tfce_neg);
+	      tfce_uncP_neg = tfce_uncP_neg + (par_tfce_neg - tol < tfce_neg);
       end
       
       % Record maxima for TFCE FWE p values.
       maxTFCEScore(b+1) = max(tfce(:));
       if SwE.WB.stat == 'T'
-	maxTFCEScore_neg(b+1) = max(tfce_neg(:));
+	      maxTFCEScore_neg(b+1) = max(tfce_neg(:));
       end
       
       clear tfce tfce_neg
@@ -1876,7 +1879,7 @@ for b = 1:WB.nB
       end
       clear cCovBc
     end
-    uncP = uncP + (score >= originalScore); 
+    uncP = uncP + (score > originalScore - tol); 
     
     maxScore(b+1) = max(score);
     if (SwE.WB.stat == 'T')
@@ -1978,7 +1981,6 @@ if isMat
   %
   % - write out lP_FWE+ and lP_FWE- ;
   %
-  tol = 1e-4;	% Tolerance for comparing real numbers
   
   FWERP = ones(1, S); % 1 because the original maxScore is always > original Score
   
@@ -2050,7 +2052,7 @@ if isMat
     clusterFwerP_pos_perCluster = ones(1, SwE.WB.clusterInfo.nCluster); % 1 because the original maxScore is always > original Score
     if (~isempty(SwE.WB.clusterInfo.clusterSize))
       for b = 1:WB.nB
-        clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster + (maxClusterSize(b+1) >= SwE.WB.clusterInfo.clusterSize);
+        clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster + (maxClusterSize(b+1) > SwE.WB.clusterInfo.clusterSize - tol);
       end
       clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster / (WB.nB + 1);
     end
@@ -2078,7 +2080,7 @@ if isMat
       clusterFwerP_neg_perCluster = ones(1, SwE.WB.clusterInfo.nClusterNeg); % 1 because the original maxScore is always > original Score
       if (~isempty(SwE.WB.clusterInfo.clusterSizeNeg))
         for b = 1:WB.nB
-          clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster + (maxClusterSizeNeg(b+1) >= SwE.WB.clusterInfo.clusterSizeNeg);
+          clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster + (maxClusterSizeNeg(b+1) > SwE.WB.clusterInfo.clusterSizeNeg - tol);
         end
         clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster / (WB.nB + 1);
       end
@@ -2136,7 +2138,6 @@ else
   %
   % - write out lP_FWE+ and lP_FWE- images;
   %
-  tol = 1e-4;	% Tolerance for comparing real numbers
   
   FWERP = ones(1, S); % 1 because the original maxScore is always > original Score
   
@@ -2230,7 +2231,7 @@ else
     clusterFwerP_pos_perCluster = ones(1, SwE.WB.clusterInfo.nCluster); % 1 because the original maxScore is always > original Score
     if (~isempty(SwE.WB.clusterInfo.clusterSize))
       for b = 1:WB.nB
-        clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster + (maxClusterSize(b+1) >= SwE.WB.clusterInfo.clusterSize);
+        clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster + (maxClusterSize(b+1) > SwE.WB.clusterInfo.clusterSize - tol);
       end
       clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster / (WB.nB + 1);
     end
@@ -2250,7 +2251,7 @@ else
       clusterFwerP_neg_perCluster = ones(1, SwE.WB.clusterInfo.nClusterNeg); % 1 because the original maxScore is always > original Score
       if (~isempty(SwE.WB.clusterInfo.clusterSizeNeg))
         for b = 1:WB.nB
-          clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster + (maxClusterSizeNeg(b+1) >= SwE.WB.clusterInfo.clusterSizeNeg);
+          clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster + (maxClusterSizeNeg(b+1) > SwE.WB.clusterInfo.clusterSizeNeg - tol);
         end
         clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster / (WB.nB + 1);
       end

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -934,7 +934,7 @@ if ~isMat
                   catch
                       pu = spm_input(['threshold {p value}'],'+0','r',0.001,1,[0,1]);
                   end
-                  thresDesc = ['p<' num2str(u) ' (unc.)'];
+                  thresDesc = ['p<' num2str(pu) ' (unc.)'];
                   % select the WB unc. p-values within the mask
                   unc_ps = 10.^-spm_get_data(xCon(Ic).VspmP,XYZ);
 

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -908,7 +908,7 @@ if ~isMat
                   catch
                       pu = spm_input('p value (FWE)','+0','r',0.05,1,[0,1]);
                   end
-                  thresDesc = ['p=<' num2str(pu) ' (' thresDesc ')'];
+                  thresDesc = ['p<=' num2str(pu) ' (' thresDesc ')'];
                   
                   FWE_ps = 10.^-spm_get_data(xCon(Ic).VspmFWEP,XYZ);
                   

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -1014,28 +1014,27 @@ if ~isMat
                       '+1','b',['(pre-set: P=' num2str(pu) ')'],[0],0)
                   
               case 'none'  % No adjustment: p for conjunctions is p of the conjunction SwE
-                  % This is performed in the normal manor on the Z map.
+                  % This should be performed on the uncorrected WB p-values
                   %--------------------------------------------------------
                   % Record what type of clusterwise inference we are doing.
                   clustWise = 'Uncorr';
                   
                   % Cluster-forming threshold.
                   try
-                      u = xSwE.u;
+                      pu = xSwE.u;
                   catch
-                      u = spm_input(['threshold {',eSTAT,' or p value}'],'+1','r',0.001,1);
+                      pu = spm_input(['threshold {p value}'],'+0','r',0.001,1,[0,1]);
                   end
-                  if u <= 1
-                      thresDesc = ['p<' num2str(u) ' (unc.)'];
-                      switch STAT
-                          case 'T'
-                              u  = swe_invNcdf(1-u^(1/n));
-                          case 'F'
-                              u  = spm_invXcdf(1-u^(1/n),1);
-                      end
-                  else
-                      thresDesc = '';
-                  end
+                  thresDesc = ['p<' num2str(pu) ' (unc.)'];
+                  % select the WB unc. p-values within the mask
+                  unc_ps = 10.^-spm_get_data(xCon(Ic).VspmP,XYZ);
+  
+                  % Here, a parametric score threshold u would differ from voxel to voxel
+                  % Thus, setting it to NaN
+                  u = NaN
+                  
+                  % exclusive thresholding like in SPM
+                  Q = find(unc_ps < pu);
                   
                   up  = NaN;
                   Pp  = NaN;
@@ -1043,9 +1042,7 @@ if ~isMat
                   ue  = NaN;
                   Pc  = [];
                   uu = [];
-                  
-                  Q      = find(Z > u);
-          
+                            
           end
           
       % If we are doing TFCE.    

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -944,7 +944,7 @@ if ~isMat
                   
                   % exclusive thresholding like in SPM
                   Q = find(unc_ps < pu);
-                  
+
               otherwise
                   %--------------------------------------------------------------
                   fprintf('\n');                                              %-#
@@ -1150,34 +1150,20 @@ if ~isMat
                   error("unknown contrast");
               end
 
-              % select only the voxels surviving the FWER threshold
-              Q     = find(ps_fwe<fwep_c);
+              % select only the voxels surviving the FWER threshold 
+              % Here, we use an inclusive p-value threshold to be consistent with an exclusive cluster threshold
+              Q = find(ps_fwe - tol < fwep_c);
               
-              % TODO: what is k exactely?
-              % I think we can k using the max cluster sizes
-              % k = sort(SwE.WB.clusterInfo.maxClusterSize)
-              % k = k( fwep_c * (SwE.WB.nB + 1) )
-              % To obtain k we find the largest p value below the p value
-              % threshold.
-              pofclus = max(ps_fwe(ps_fwe<fwep_c));
-              
-              % Prevent error if nothing survived threshold.
-              if isempty(pofclus)
-                pofclus = -1;
+              % The exclusive threshold k should be the (1-fwep_c)th percentile of the max cluster size distribution
+              if Ic == 1
+                maxClusterSize = sort(SwE.WB.clusterInfo.maxClusterSize);
+              elseif Ic == 2
+                maxClusterSize = sort(SwE.WB.clusterInfo.maxClusterSizeNeg);
+              else
+                error("Unknown contrast");
               end
-              
-              % We then look for the size of the clusters with this p value
-              % We do this by first getting this index of clusters with
-              % this p value.
+              k = maxClusterSize( ceil( (1-fwep_c) * (xSwE.nB+1) ) );
 
-              clusIndices = unique(A(ps_fwe==pofclus));
-              
-              % And then looping through this indices looking for the
-              % smallest cluster.
-              k = Inf;
-              for i = 1:length(clusIndices)
-                 k = min(k, sum(A==clusIndices(i)));
-              end
           end
 
           % ...eliminate voxels

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -936,7 +936,7 @@ if ~isMat
                   end
                   thresDesc = ['p<=' num2str(pu) ' (unc.)'];
                   % select the WB unc. p-values within the mask
-                  unc_ps = 10.^-spm_get_data(xCon(Ic).VspmP,XYZ);
+                  unc_ps = 10.^-spm_get_data(xCon(Ic).VspmUncP,XYZ);
 
                   % Here, a parametric score threshold u would differ from voxel to voxel
                   % Thus, setting it to NaN
@@ -1027,7 +1027,7 @@ if ~isMat
                   end
                   thresDesc = ['p<=' num2str(pu) ' (unc.)'];
                   % select the WB unc. p-values within the mask
-                  unc_ps = 10.^-spm_get_data(xCon(Ic).VspmP,XYZ);
+                  unc_ps = 10.^-spm_get_data(xCon(Ic).VspmUncP,XYZ);
   
                   % Here, a parametric score threshold u would differ from voxel to voxel
                   % Thus, setting it to NaN

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -927,25 +927,24 @@ if ~isMat
                   Q = find(FDR_ps < pu);
 
               case 'none'  % No adjustment: p for conjunctions is p of the conjunction SwE
-                  % This is performed in the normal manor on the Z map.
+                  % This should be performed on the uncorrected WB p-values
                   %--------------------------------------------------------
                   try
-                      u = xSwE.u;
+                      pu = xSwE.u;
                   catch
-                      u = spm_input(['threshold {',eSTAT,' or p value}'],'+0','r',0.001,1);
+                      pu = spm_input(['threshold {p value}'],'+0','r',0.001,1,[0,1]);
                   end
-                  if u <= 1
-                      thresDesc = ['p<' num2str(u) ' (unc.)'];
-                      switch STAT
-                          case 'T'
-                              u  = swe_invNcdf(1-u^(1/n));
-                          case 'F'
-                              u  = spm_invXcdf(1-u^(1/n),1);
-                      end
-                  else
-                      thresDesc = '';
-                  end
+                  thresDesc = ['p<' num2str(u) ' (unc.)'];
+                  % select the WB unc. p-values within the mask
+                  unc_ps = 10.^-spm_get_data(xCon(Ic).VspmP,XYZ);
 
+                  % Here, a parametric score threshold u would differ from voxel to voxel
+                  % Thus, setting it to NaN
+                  u = NaN
+                  
+                  % exclusive thresholding like in SPM
+                  Q = find(unc_ps < pu);
+                  
               otherwise
                   %--------------------------------------------------------------
                   fprintf('\n');                                              %-#

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -915,17 +915,17 @@ if ~isMat
                       pu = spm_input('p value (FDR)','+0','r',0.05,1,[0,1]);
                   end
                   thresDesc = ['p<' num2str(pu) ' (' thresDesc ')'];
-
-                  FDR_ps = 10.^-spm_get_data(xCon(Ic).VspmFDRP,XYZum);
-                                    
-                  % Obtain statistic threshold
-                  switch STAT
-                      case 'T'
-                         u = spm_uc_FDR(pu,Inf,'Z',n,VspmSv,0); 
-                      case 'F'
-                         u = spm_uc_FDR(pu,[1 1],'X',n,VspmSv,0); 
-                  end
                   
+                  % select the WB FDR p-values within the mask
+                  FDR_ps = 10.^-spm_get_data(xCon(Ic).VspmFDRP,XYZ);
+
+                  % Here, a parametric score threshold u would differ from voxel to voxel
+                  % Thus, setting it to NaN
+                  u = NaN
+                  
+                  % exclusive thresholding like in SPM
+                  Q = find(FDR_ps < pu);
+
               case 'none'  % No adjustment: p for conjunctions is p of the conjunction SwE
                   % This is performed in the normal manor on the Z map.
                   %--------------------------------------------------------
@@ -958,8 +958,6 @@ if ~isMat
           ue  = NaN;
           Pc  = [];
           uu = [];
-
-          Q = find(Z > u);
 
       % If we are doing clusterwise WB.
       elseif isfield(SwE, 'WB') && infType == 1

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -926,7 +926,7 @@ if ~isMat
                   else
                     error("Unknown contrast");
                   end
-                  u = maxScore( ceil( (1-pu) * (xSwE.nB+1) ) );
+                  u = maxScore( ceil( (1-pu) * (SwE.WB.nB+1) ) );
 
               case 'FDR' % False discovery rate
                   % This is performed on the FDR P value map
@@ -1181,7 +1181,7 @@ if ~isMat
               else
                 error("Unknown contrast");
               end
-              k = maxClusterSize( ceil( (1-fwep_c) * (xSwE.nB+1) ) );
+              k = maxClusterSize( ceil( (1-fwep_c) * (SwE.WB.nB+1) ) );
 
           end
 

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -914,7 +914,7 @@ if ~isMat
                   catch
                       pu = spm_input('p value (FDR)','+0','r',0.05,1,[0,1]);
                   end
-                  thresDesc = ['p<' num2str(pu) ' (' thresDesc ')'];
+                  thresDesc = ['p<=' num2str(pu) ' (' thresDesc ')'];
                   
                   % select the WB FDR p-values within the mask
                   FDR_ps = 10.^-spm_get_data(xCon(Ic).VspmFDRP,XYZ);
@@ -923,8 +923,8 @@ if ~isMat
                   % Thus, setting it to NaN
                   u = NaN
                   
-                  % exclusive thresholding like in SPM
-                  Q = find(FDR_ps < pu);
+                  % inclusive thresholding for WB
+                  Q = find(FDR_ps - tol < pu);
 
               case 'none'  % No adjustment: p for conjunctions is p of the conjunction SwE
                   % This should be performed on the uncorrected WB p-values
@@ -934,7 +934,7 @@ if ~isMat
                   catch
                       pu = spm_input(['threshold {p value}'],'+0','r',0.001,1,[0,1]);
                   end
-                  thresDesc = ['p<' num2str(pu) ' (unc.)'];
+                  thresDesc = ['p<=' num2str(pu) ' (unc.)'];
                   % select the WB unc. p-values within the mask
                   unc_ps = 10.^-spm_get_data(xCon(Ic).VspmP,XYZ);
 
@@ -942,8 +942,8 @@ if ~isMat
                   % Thus, setting it to NaN
                   u = NaN
                   
-                  % exclusive thresholding like in SPM
-                  Q = find(unc_ps < pu);
+                  % inclusive thresholding for WB
+                  Q = find(unc_ps - tol < pu);
 
               otherwise
                   %--------------------------------------------------------------
@@ -1025,7 +1025,7 @@ if ~isMat
                   catch
                       pu = spm_input(['threshold {p value}'],'+0','r',0.001,1,[0,1]);
                   end
-                  thresDesc = ['p<' num2str(pu) ' (unc.)'];
+                  thresDesc = ['p<=' num2str(pu) ' (unc.)'];
                   % select the WB unc. p-values within the mask
                   unc_ps = 10.^-spm_get_data(xCon(Ic).VspmP,XYZ);
   
@@ -1033,8 +1033,8 @@ if ~isMat
                   % Thus, setting it to NaN
                   u = NaN
                   
-                  % exclusive thresholding like in SPM
-                  Q = find(unc_ps < pu);
+                  % inclusive thresholding for WB
+                  Q = find(unc_ps - tol < pu);
                   
                   up  = NaN;
                   Pp  = NaN;

--- a/swe_list.m
+++ b/swe_list.m
@@ -598,21 +598,25 @@ case 'table'                                                        %-Table
 %                 Qp  = [];
 %             end
 %         else
-            switch STATe
-                case 'Z'
-                  try
-                    Pz      = normcdf(-U);
-                  catch
-                    Pz      = spm_Ncdf(-U);
-                  end
-                case 'X'
-                  try
-                    Pz      = 1-chi2cdf(U,1);
-                  catch 
-                    Pz      = 1-spm_Xcdf(U,1);
-                  end
+            if ~xSwE.WB
+              switch STATe
+                  case 'Z'
+                    try
+                      Pz      = normcdf(-U);
+                    catch
+                      Pz      = spm_Ncdf(-U);
+                    end
+                  case 'X'
+                    try
+                      Pz      = 1-chi2cdf(U,1);
+                    catch 
+                      Pz      = 1-spm_Xcdf(U,1);
+                    end
+              end
+            else
+              Pz = 10.^-VspmUncP(XYZ(1,i),XYZ(2,i),XYZ(3,i));
             end
-            
+
             % If we are not running a wild bootstrap or we are doing a 
             % small volume correction we need to calculate the FDR P value
             % and leave the other values blank.
@@ -714,7 +718,7 @@ case 'table'                                                        %-Table
                     % results we calculated earlier.
                     else
                         
-                        Pz      = spm_Ncdf(-Z(d));
+                        Pz      = 10.^-VspmUncP(XYZ(1,d),XYZ(2,d),XYZ(3,d));
                         Pu      = 10.^-VspmFWEP(XYZ(1,d),XYZ(2,d),XYZ(3,d));
                         Qu      = 10.^-VspmFDRP(XYZ(1,d),XYZ(2,d),XYZ(3,d));
                         ws     = warning('off','SPM:outOfRangeNormal');

--- a/swe_list.m
+++ b/swe_list.m
@@ -367,19 +367,27 @@ case 'table'                                                        %-Table
      % Number of `extra` lines inserted that don't have to be present in
      % every display
      exlns           = 0;
-     
-     % Record height thresholds.
-     if ~isfield(xSwE, 'TFCEthresh') || ~xSwE.TFCEthresh
-         TabDat.ftr{1,1} = ...
-              ['Threshold: Height ' eSTAT ' = %0.2f, p = %0.3f; Extent k = %0.0f voxels.'];
-         TabDat.ftr{1,2} = [u,Pz,k];
-     else
-         TabDat.ftr{1,1} = 'Threshold: TFCE %s';
-         TabDat.ftr{1,2} = xSwE.thresDesc;
-     end
-     
+
      if xSwE.WB
-     
+        % Record thresholds.
+        if ~isfield(xSwE, 'TFCEthresh') || ~xSwE.TFCEthresh
+            td = regexp(xSwE.thresDesc,'p\D+?(?<u>[\.\d]+) \((?<thresDesc>\S+)\)','names');
+            if strcmpr(td.thresDesc, 'FWE')
+              TabDat.ftr{1,1} = ['Threshold: Height ' eSTAT ' > %0.2f, p >= %0.3f (FWE); Extent k >= %0.0f voxels.'];;
+              TabDat.ftr{1,2} = [u, td.u, k];
+            elseif strcmpr(td.thresDesc, 'FDR')
+              TabDat.ftr{1,1} = ['Threshold: p >= %0.3f (FDR); Extent k >= %0.0f voxels.'];;
+              TabDat.ftr{1,2} = [td.u, k];
+            elseif strcmpr(td.thresDesc, 'Unc.')
+              TabDat.ftr{1,1} = ['Threshold: p >= %0.3f (Unc.); Extent k >= %0.0f voxels.'];;
+              TabDat.ftr{1,2} = [td.u, k];
+            else
+              error('Unknown inference type detected')
+            end
+        else
+            TabDat.ftr{1,1} = 'Threshold: TFCE %s';
+            TabDat.ftr{1,2} = xSwE.thresDesc;
+        end
         % We need the P uncorrected P values to be in the correct form to
         % use spm_uc_FDR.
         Ts = spm_data_read(xSwE.VspmUncP);
@@ -403,7 +411,10 @@ case 'table'                                                        %-Table
             TabDat.ftr{2,2} = [xSwE.Pfv, FDRp_05];
         end
      else
-         
+        % Record height thresholds.
+        TabDat.ftr{1,1} = ...
+        ['Threshold: Height ' eSTAT ' = %0.2f, p = %0.3f; Extent k = %0.0f voxels.'];
+        TabDat.ftr{1,2} = [u,Pz,k];         
         % Record FDR p value.
         TabDat.ftr{2,1} = ...
              'vox P(5%% FDR): %0.3f';

--- a/swe_list.m
+++ b/swe_list.m
@@ -368,25 +368,45 @@ case 'table'                                                        %-Table
      % every display
      exlns           = 0;
 
+     % detect whether the WB was done based on Z/X or on T/F using the version number (2.1.1 was the last using T/F)
+     if swe_compareVersions(swe('ver'), '2.1.1', '>')
+      displaySTAT = eSTAT;
+     else
+      displaySTAT = STAT;
+     end
+
      if xSwE.WB
         % Record thresholds.
-        if ~isfield(xSwE, 'TFCEthresh') || ~xSwE.TFCEthresh
-            td = regexp(xSwE.thresDesc,'p\D+?(?<u>[\.\d]+) \((?<thresDesc>\S+)\)','names');
-            if strcmpr(td.thresDesc, 'FWE')
-              TabDat.ftr{1,1} = ['Threshold: Height ' eSTAT ' > %0.2f, p >= %0.3f (FWE); Extent k >= %0.0f voxels.'];;
-              TabDat.ftr{1,2} = [u, td.u, k];
-            elseif strcmpr(td.thresDesc, 'FDR')
-              TabDat.ftr{1,1} = ['Threshold: p >= %0.3f (FDR); Extent k >= %0.0f voxels.'];;
-              TabDat.ftr{1,2} = [td.u, k];
-            elseif strcmpr(td.thresDesc, 'Unc.')
-              TabDat.ftr{1,1} = ['Threshold: p >= %0.3f (Unc.); Extent k >= %0.0f voxels.'];;
-              TabDat.ftr{1,2} = [td.u, k];
+        % For voxel-wise FDR and unc. thresholding, we cannot display a score threshold as it varies per voxel
+        td = regexp(xSwE.thresDesc,'p\D+?(?<u>[\.\d]+) \((?<thresDesc>\S+)\)','names');
+        if xSwE.infType == 0 % voxel-wise
+            if strcmp(td.thresDesc, 'FWE')
+              TabDat.ftr{1,1} = ['Threshold: Height ' displaySTAT ' > %0.2f, p <= %0.3f (FWE); Extent k >= %0.0f voxels.'];
+              TabDat.ftr{1,2} = [u, str2num(td.u), k];
+            elseif strcmp(td.thresDesc, 'FDR')
+              TabDat.ftr{1,1} = ['Threshold: p <= %0.3f (FDR); Extent k >= %0.0f voxels.'];
+              TabDat.ftr{1,2} = [str2num(td.u), k];
+            elseif strcmp(td.thresDesc, 'unc.')
+              TabDat.ftr{1,1} = ['Threshold: p <= %0.3f (unc.); Extent k >= %0.0f voxels.'];
+              TabDat.ftr{1,2} = [str2num(td.u), k];
             else
               error('Unknown inference type detected')
             end
-        else
+        elseif xSwE.infType == 1 % cluster-wise
+            if strcmp(xSwE.clustWise, 'FWE')
+              TabDat.ftr{1,1} = ['Threshold: Height ' eSTAT ' > %0.2f, p < %0.3f (unc.); Extent k > %0.0f voxels, p <= %0.3f (FWE).'];
+              TabDat.ftr{1,2} = [u, str2num(td.u), k, xSwE.fwep_c];
+            elseif strcmp(xSwE.clustWise, 'Uncorr')
+              TabDat.ftr{1,1} = ['Threshold: p <= %0.3f (unc.); Extent k >= %0.0f voxels.'];
+              TabDat.ftr{1,2} = [str2num(td.u), k];
+            else
+              error('Unknown inference type detected')
+            end
+        elseif xSwE.infType == 2 % TFCE
             TabDat.ftr{1,1} = 'Threshold: TFCE %s';
             TabDat.ftr{1,2} = xSwE.thresDesc;
+        else
+            error('Unknown inference type detected')
         end
         % We need the P uncorrected P values to be in the correct form to
         % use spm_uc_FDR.
@@ -401,13 +421,13 @@ case 'table'                                                        %-Table
         
         % Record FWE/FDR/clus FWE p values. (No clus FWE for voxelwise and
         % TFCE analyses)
-        if isfield(xSwE, 'Pfc')
+        if xSwE.infType == 1 && strcmp(xSwE.clustWise, 'FWE')
             TabDat.ftr{2,1} = ...
-                 ['vox ' STAT '(5%% FWE): %0.3f, vox P(5%% FDR): %0.3f, clus k(5%% FWE): %0.0f '];
+                 ['vox ' displaySTAT '(5%% FWE): %0.3f, vox P(5%% FDR): %0.3f, clus k(5%% FWE): %0.0f '];
             TabDat.ftr{2,2} = [xSwE.Pfv, FDRp_05, xSwE.Pfc];
         else
             TabDat.ftr{2,1} = ...
-                 ['vox ' STAT '(5%% FWE): %0.3f, vox P(5%% FDR): %0.3f'];
+                 ['vox ' displaySTAT '(5%% FWE): %0.3f, vox P(5%% FDR): %0.3f'];
             TabDat.ftr{2,2} = [xSwE.Pfv, FDRp_05];
         end
      else
@@ -651,7 +671,7 @@ case 'table'                                                        %-Table
                 ws      = warning('off','SPM:outOfRangeNormal');
                 warning(ws);
                 
-                if isfield(xSwE, 'VspmFWEP_clus')
+                if xSwE.infType == 1 && strcmp(xSwE.clustWise, 'FWE') % only for FWER clusterwise WB
                     Pk      = 10.^-VspmFWEP_clus(XYZ(1,i),XYZ(2,i),XYZ(3,i));
                     % It is possible to get the results window to display
                     % details about voxels that were thresholded out by the
@@ -849,7 +869,7 @@ case 'table'                                                        %-Table
         set(gca,'DefaultTextFontName',PF.helvetica,...
             'DefaultTextInterpreter','None','DefaultTextFontSize',FS(8))
         
-        fx = repmat([0 0.5],ceil(size(TabDat.ftr,1)/2),1);
+        fx = repmat([0 0.645],ceil(size(TabDat.ftr,1)/2),1);
         fy = repmat((1:ceil(size(TabDat.ftr,1)/2))',1,2);
         for i=1:size(TabDat.ftr,1)
             text(fx(i),-fy(i)*dy,sprintf(TabDat.ftr{i,1},TabDat.ftr{i,2}),...

--- a/swe_list.m
+++ b/swe_list.m
@@ -425,7 +425,7 @@ case 'table'                                                        %-Table
          end
 
          % Record visits per group.
-         nVisitsString = 'Number of visits ([Mn Max]): ';
+         nVisitsString = 'Number of visits ([Min Max]): ';
          nVisitsNumbers = [];
          for i = 1:length(xSwE.max_nVis_g)
              nVisitsString = [nVisitsString '[%0.0f %0.0f]'];

--- a/swe_results_ui.m
+++ b/swe_results_ui.m
@@ -1218,7 +1218,7 @@ xSwE2.pm    = xSwE.pm;
 xSwE2.Ex    = xSwE.Ex;
 xSwE2.title = '';
 if ~isempty(xSwE.thresDesc)
-    td = regexp(xSwE.thresDesc,'p\D?(?<u>[\.\d]+) \((?<thresDesc>\S+)\)','names');
+    td = regexp(xSwE.thresDesc,'p\D+?(?<u>[\.\d]+) \((?<thresDesc>\S+)\)','names');
     if isempty(td)
         td = regexp(xSwE.thresDesc,'\w=(?<u>[\.\d]+)','names');
         td.thresDesc = 'none';

--- a/swe_results_ui.m
+++ b/swe_results_ui.m
@@ -266,6 +266,14 @@ switch lower(Action), case 'setup'                         %-Set up results
         case 'F'
             eSTAT = 'X';
     end
+
+    % detect whether the WB was done based on Z/X or on T/F using the version number (2.1.1 was the last using T/F)
+    if swe_compareVersions(swe('ver'), '2.1.1', '>')
+      displaySTAT = eSTAT;
+    else
+      displaySTAT = xSwE.STAT;
+    end
+
     %-Ensure pwd = swd so that relative filenames are valid
     %----------------------------------------------------------------------
     cd(SwE.swd)
@@ -422,21 +430,23 @@ switch lower(Action), case 'setup'                         %-Set up results
             td = regexp(xSwE.thresDesc,'p\D+?(?<u>[\.\d]+) \((?<thresDesc>\S+)\)','names');
             if ~strcmp(xSwE.thresDesc, 'none') && ~isempty(xSwE.thresDesc)
               % Do not show height threshold if unc or FDR voxel-wise WB threshold
-              if isfield(xSwE, 'WB') && xSwE.WB && ~strcmp(td.thresDesc, 'FWE') % (voxel-wise WB inference)
+              if isfield(xSwE, 'WB') && xSwE.WB && xSwE.infType == 0 && ~strcmp(td.thresDesc, 'FWE') % (voxel-wise WB inference)
                 text(0,12,sprintf('Wild Bootstrap p-value threshold %s',thresDesc),'Parent',hResAx)
               elseif isfield(xSwE, 'WB') && xSwE.WB && xSwE.infType == 0 && strcmp(td.thresDesc, 'FWE')
-                text(0,12,sprintf('Wild Bootstrap height threshold %c > %0.6f  {%s}',eSTAT,xSwE.u,thresDesc),'Parent',hResAx)
+                text(0,12,sprintf('Wild Bootstrap height threshold %c > %0.6f  {%s}',displaySTAT,xSwE.u,thresDesc),'Parent',hResAx)
+              elseif isfield(xSwE, 'WB') && xSwE.WB && xSwE.infType == 1 && strcmp(xSwE.clustWise, 'Uncorr')
+                text(0,12,sprintf('Wild Bootstrap p-value threshold %s',thresDesc),'Parent',hResAx)
               else
-                text(0,12,sprintf('Height threshold %c = %0.6f  {%s}',eSTAT,xSwE.u,thresDesc),'Parent',hResAx)               
+                text(0,12,sprintf('Height threshold %c > %0.6f  {%s}',eSTAT,xSwE.u,thresDesc),'Parent',hResAx)               
               end
             else
-                text(0,12,sprintf('Height threshold %c = %0.6f',eSTAT,xSwE.u),'Parent',hResAx)
+                text(0,12,sprintf('Height threshold %c > %0.6f',eSTAT,xSwE.u),'Parent',hResAx)
             end
         catch
-            text(0,12,sprintf('Height threshold %c = %0.6f',eSTAT,xSwE.u),'Parent',hResAx)
+            text(0,12,sprintf('Height threshold %c > %0.6f',eSTAT,xSwE.u),'Parent',hResAx)
         end
         if strcmp(xSwE.clustWise, 'FWE') 
-            text(0,00,sprintf('Extent threshold k > %0.0f voxels {p<=%0.3f (FWE)}',xSwE.k, xSwE.fwep_c), 'Parent',hResAx)
+            text(0,00,sprintf('Wild Bootstrap extent threshold k > %0.0f voxels {p<=%0.3f (FWE)}',xSwE.k, xSwE.fwep_c), 'Parent',hResAx)
         else
             text(0,00,sprintf('Extent threshold k >= %0.0f voxels',xSwE.k), 'Parent',hResAx)
         end
@@ -451,7 +461,7 @@ switch lower(Action), case 'setup'                         %-Set up results
     else
         try
             thresDesc = xSwE.thresDesc;
-            text(0,12,sprintf('TFCE threshold %s', thresDesc),'Parent',hResAx)
+            text(0,12,sprintf('Wild Bootstrap TFCE threshold %s', thresDesc),'Parent',hResAx)
             text(0,00,sprintf('Wild Bootstrap'), 'Parent',hResAx)
         catch
             error('Unknown TFCE threshold.')

--- a/swe_results_ui.m
+++ b/swe_results_ui.m
@@ -419,8 +419,16 @@ switch lower(Action), case 'setup'                         %-Set up results
     if ~isfield(xSwE, 'TFCEthresh') || ~xSwE.TFCEthresh
         try
             thresDesc = xSwE.thresDesc;
+            td = regexp(xSwE.thresDesc,'p\D+?(?<u>[\.\d]+) \((?<thresDesc>\S+)\)','names');
             if ~strcmp(xSwE.thresDesc, 'none') && ~isempty(xSwE.thresDesc)
-                text(0,12,sprintf('Height threshold %c = %0.6f  {%s}',eSTAT,xSwE.u,thresDesc),'Parent',hResAx)
+              % Do not show height threshold if unc or FDR voxel-wise WB threshold
+              if isfield(xSwE, 'WB') && xSwE.WB && ~strcmp(td.thresDesc, 'FWE') % (voxel-wise WB inference)
+                text(0,12,sprintf('Wild Bootstrap p-value threshold %s',thresDesc),'Parent',hResAx)
+              elseif isfield(xSwE, 'WB') && xSwE.WB && xSwE.infType == 0 && strcmp(td.thresDesc, 'FWE')
+                text(0,12,sprintf('Wild Bootstrap height threshold %c > %0.6f  {%s}',eSTAT,xSwE.u,thresDesc),'Parent',hResAx)
+              else
+                text(0,12,sprintf('Height threshold %c = %0.6f  {%s}',eSTAT,xSwE.u,thresDesc),'Parent',hResAx)               
+              end
             else
                 text(0,12,sprintf('Height threshold %c = %0.6f',eSTAT,xSwE.u),'Parent',hResAx)
             end
@@ -428,9 +436,9 @@ switch lower(Action), case 'setup'                         %-Set up results
             text(0,12,sprintf('Height threshold %c = %0.6f',eSTAT,xSwE.u),'Parent',hResAx)
         end
         if strcmp(xSwE.clustWise, 'FWE') 
-            text(0,00,sprintf('Extent threshold k = %0.0f voxels {p<%0.3f (FWE)}',xSwE.k, xSwE.fwep_c), 'Parent',hResAx)
+            text(0,00,sprintf('Extent threshold k > %0.0f voxels {p<=%0.3f (FWE)}',xSwE.k, xSwE.fwep_c), 'Parent',hResAx)
         else
-            text(0,00,sprintf('Extent threshold k = %0.0f voxels',xSwE.k), 'Parent',hResAx)
+            text(0,00,sprintf('Extent threshold k >= %0.0f voxels',xSwE.k), 'Parent',hResAx)
         end
         try
             WB = xSwE.WB;


### PR DESCRIPTION
The main goal of this PR is to modify the way the thresholding and the display of results are done for the Wild Bootstrap. Some additional improvements, not necessarily related, have also been done. Below is a brief summary with explanations of the changes:

### Changes mainly related to the thresholding
- The WB thresholding is now inclusive when done on the p-values and exclusive when done on the score.
- The WB score thresholds are now computed as the (1-alpha)th percentile of the score distributions. Before it was computed as the largest score not surviving the thresholding.
- The thresholding for voxel-wise uncorrected inference is now done on the WB uncorrected p-values instead of the parametric uncorrected p-values.
- Some piece of code has also been modified in such a way that the WB thresholding can be done on images that would be masked by a post-hoc masking. In particular, we use now the variable `XYZ` instead of the variable `XYZum` Note that this post-hoc masking is currently disabled for WB, but might be enabled in a future PR. 
- swe_contrasts_WB now links to the WB uncorrected p-values instead of the parametric uncorrected p-values. This is necessary to threshold and display the WB uncorrected p-value instead of the parametric p-values.
- In swe_getSPM, we check if SwE.xCon links to the WB uncorrected p-values instead of the parametric p-values. If this is not the case, we correct this and overwrite SwE.mat. This is necessary for scenarios where SwE.xCon had been produced using an old version of swe_contrasts_WB.

### Changes mainly related to the display of results
- We now do not report a score threshold for voxel-wise WB inferences as these are voxel-dependent. Before, the parametric score threshold was shown.
- The score threshold for FWER voxel-wise inference is reported as a T/F-score for models estimated using a version older than or equal to 2.1.1. It is reported as a Z/X-score otherwise. This is to comply with PR #129.
- Now the WB p-value treshold are reported as inclusive and the WB score threshold as exclusive.
- The WB cluster-wise FWER p-values are now only reported if this a WB cluster-wise FWER is requested by the user.
- The left side of the footer has been reduced in width to avoid text collision with the right side when the threshold info of a WB cluster-wise inference is reported
- When a threshold is specificaly from the WB, it is indicated now that this a Wild Bootstrap threshold. For example, `Extent threshold` --> `Wild Bootstrap extent threshold`.

### Changes mainly related to the computation of statistics
- The TFCE  and cluster-wise WB FWER p-values are now computed using the tolerance trick (i.e. `a >= b` is replaced by `a > b - tolerance`).
- The maximum TFCE scores are now saved into `SwE.WB.TFCE.maxTFCEScore` and `SwE.WB.TFCE.maxTFCEScore_neg`(before they were not recorded).

### Miscellaneous 
- A new function `swe_compareVersions` has been added. It can compare version numbers of type x.x.x and is currently used to detect whether the voxel-wise WB p-values were based on T/F-scores or on F/X-scores.
- Typo fix: `Mn` is replaced by `Min`

Note that this PR is relatively hard to check as this is mainly related to the way the results are displayed. I have already checked this several times if all the changes looks ok to me. Tomorrow, I will check this again one more time and append some screenshots showing the changes for each type inference (before/ after the PR). That will help us to check if the changes are indeed useful and correct.
