### PR TITLE
Fix the result display error observed for the classic parametric SwE

### DIFF
--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -1243,11 +1243,12 @@ if isfield(SwE.type, 'modified')
     xSwE.nSubj_g    = SwE.Gr.nSubj_g;
     xSwE.max_nVis_g = SwE.Vis.max_nVis_g;
     xSwE.min_nVis_g = SwE.Vis.min_nVis_g;
-    xSwE.Vedf       = cat(1,xCon(Ic).Vedf);
+end
+
+if SwE.dof.dof_type == 0
+  xSwE.edf = xCon(Ic).edf;
 else
-    if ~isfield(SwE, 'WB')
-        xSwE.edf        = xCon(Ic).edf;
-    end
+  xSwE.Vedf = cat(1,xCon(Ic).Vedf);
 end
 
 % For WB analyses we have already computed uncorrected, FDR, FWE and


### PR DESCRIPTION
The source of the error (see issue #132 ) seems to be due to the fact that the appropriate information about the number of degrees of freedom was not saved correctly for the classic parametric SwE in swe_getSPM.

In brief, before this PR, the variable edf was saved into xSWE for all parametric analysis and Vedf was saved into xSWE only for all analysis using the modified SwE. These 2 conditions seem weird as the scalar value edf is only relevant for a naïve estimation of the numbers of degree of freedom that is assumed constant across the brain (i.e. when SwE.dof.dof_type == 0). In addition, in all the other cases (i.e. when SwE.dof.dof_type > 0), the numbers of degree of freedom is potentially varying accross voxels and saved into the image Vedf. Thus, in this PR, we use now a condition on SwE.dof.dof_type to decide which variable to save.

This PR seems to fix the issue #132.