### PR TITLE
use the resampling matrix in SwE.WB if it exists

### DIFF
--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1543,13 +1543,21 @@ end
 %- Produce bootstraps and maximum stats 
 %==========================================================================
 
-% Produce the random value following the Rademacher distribution
-resamplingMatrix = NaN(nScan,WB.nB);
-for iS = 1:nSubj
-  % resamplingMatrix(iSubj == uSubj(iS),:) = repmat(binornd(1, 0.5, 1, WB.nB), sum(iSubj == uSubj(iS)), 1);
-  resamplingMatrix(iSubj == uSubj(iS),:) = repmat(randi([0 1], 1, WB.nB), sum(iSubj == uSubj(iS)), 1);  % BG (08/11/2016): using randi instead of binornd (which is from the stats toolbox)
+% check whether a resampling Matrix exists in SwE. If yes, use it. If not, produce it.
+if isfield(SwE.WB, 'resamplingMatrix')
+  resamplingMatrix = SwE.WB.resamplingMatrix;
+  if any(size(resamplingMatrix) ~= [nScan WB.nB])
+    error('The supplied resampling matrix does not have the good dimensions');
+  end
+else
+  % Produce the random value following the Rademacher distribution
+  resamplingMatrix = NaN(nScan,WB.nB);
+  for iS = 1:nSubj
+    % resamplingMatrix(iSubj == uSubj(iS),:) = repmat(binornd(1, 0.5, 1, WB.nB), sum(iSubj == uSubj(iS)), 1);
+    resamplingMatrix(iSubj == uSubj(iS),:) = repmat(randi([0 1], 1, WB.nB), sum(iSubj == uSubj(iS)), 1);  % BG (08/11/2016): using randi instead of binornd (which is from the stats toolbox)
+  end
+  resamplingMatrix(resamplingMatrix == 0) = -1;
 end
-resamplingMatrix(resamplingMatrix == 0) = -1;
 
 % load original score
 if isMat


### PR DESCRIPTION
The goal of this PR is to add an "hidden" option to supply a WB resampling matrix instead of letting the toolbox to randomly generate one. This is achieved by adding to SwE.WB a field SwE.WB.resamplingMatrix with the WB resampling matrix. This is "hidden" in the sense that the user must added manually through code and not though the toolbox itself. I made this option "hidden" in order to limit the possibility for some users to feed a "wrong" WB resampling matrix. 

Note that this PR is very useful in order to test the toolbox and compare its results to those of the fsl version.

