### PR TITLE
Add the number of degrees of freedom Approximation I for the WB

### DIFF
--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1413,7 +1413,6 @@ else % ".mat" format
         else
           hyptest=swe_hyptest(SwE, score, CrS, cCovBc, Cov_vis, dofMat);
         end
-        hyptest=swe_hyptest(SwE, score, CrS, cCovBc, Cov_vis, dofMat);
         p = hyptest.positive.p;
         edf = hyptest.positive.edf;
         clear CovcCovBc cCovBc
@@ -1911,11 +1910,8 @@ for b = 1:WB.nB
       % Calculate TFCE uncorrected p image.
       if TFCE    
 
-	% Obtain P values.
-	hyptest=swe_hyptest(SwE, score, blksz, cCovBc, Cov_vis, dofMat);
-	
-	% Current XYZ indices
-	currXYZ = XYZ(1:3, index);
+        % Current XYZ indices
+        currXYZ = XYZ(1:3, index);
 	  
         % T test already converted to Z
         if strcmp(WB.stat, 'T')

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -320,6 +320,9 @@ end
 
 %-preprocessing for the modified SwE
 if isfield(SwE.type,'modified')
+  if dof_type == 1
+    error('degrees of freedom type still not implemented for the modified SwE and the WB')
+  end
   iVis      = SwE.Vis.iVis;
   iGr       = SwE.Gr.iGr;
   uGr       = unique(iGr); 


### PR DESCRIPTION
The goal of this PR is to add the option to use `Approximation I` as a usable estimator for the number of degrees of freedom when a WB analysis is performed. Before this PR, this was not implemented and an error message was thrown to indicate this to the user. 

I have tested this PR for the classic SwE using the image format and the results match those of the fsl version of the toolbox. Thus, I can assume that this PR is correct for this particular scenario. Nevertheless, the code is also implemented for the modified version of the SwE and when the input is a ".mat" format. Those cases would need to be checked before merging this PR.

Note also that the code is not very pretty because I had to do it quickly in order to be able to check the fsl version of the toolbox on this type of estimator for the classic SwE. In particular, the edf is computed alongside the contrasted SwE computation because we need to have access to each group (for the modifed SwE) or subject (for the classic SwE) contribution. These contributions were only available during the contrasted SwE computation. Therefore, they are not available when the subfunction swe_hyptest is called. Thus, swe_hyptest cannot be used without a strong refactoring to compute this edf approximation. I feel that the subfunction swe_hyptest would need to be refactored in order to compute the SwE within it. However, I believe other tasks are more urgent before doing that.