### PR TITLE
Release SwE Version 2.2.0.rc

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -59,7 +59,7 @@ switch lower(Action)
         %==================================================================
     case 'asciiwelcome'                          %-ASCII swe banner welcome
         %==================================================================
-        a = generateAscii(['SwE v' versionNo]);
+        a = generateAscii(['SwE v' replace(versionNo,'.rc','')]);
         fprintf('%s \n', a{1}, a{2}, a{3}, a{4});
         fprintf('swe v%s \n', versionNo);
   

--- a/swe.m
+++ b/swe.m
@@ -11,7 +11,7 @@ function varargout = swe(varargin)
 % Written by Bryan Guillaume
 % Version Info:  $Format:%ci$ $Format:%h$
 
-versionNo = '2.1.1';
+versionNo = '2.2.0.rc';
 
 try
   Modality = spm_get_defaults('modality');

--- a/swe_checkCompat.m
+++ b/swe_checkCompat.m
@@ -45,6 +45,7 @@ function swe_checkCompat(matVer, tbVer)
     earliestCompatVer('2.0.0') = '2.0.0';
     earliestCompatVer('2.1.0') = '2.0.0';
     earliestCompatVer('2.1.1') = '2.0.0';
+    earliestCompatVer('2.2.0.rc') = '2.0.0';
  
     % The below line works out the latest compatible version from the
     % earliest compatible versions. This code is now redundant but may be

--- a/swe_compareVersions.m
+++ b/swe_compareVersions.m
@@ -15,6 +15,13 @@ function result = swe_compareVersions(ver1, ver2, comparisonOperator)
   ver1 = strsplit(ver1, '.');
   ver2 = strsplit(ver2, '.');
   
+  if numel(ver1) > 3
+    ver1 = ver1(1:3);
+  end
+ 
+  if numel(ver2) > 3
+    ver2 = ver2(1:3);
+  end
   % Work out base for comparison.
   base = max(cellfun(@(a) str2num(a), {ver1{:} ver2{:}})) + 1;
   


### PR DESCRIPTION
### Changes made since the previous version

- enh: add GIfTI support
- enh: add CIfTI support
- enh: all the non-parametric WB p-values are now computed using a tolerance of 10^-8 for comparing real numbers
- enh: the maximum TFCE scores are now saved into SwE.mat
- enh: the WB procedure now makes voxel-wise inference on Z or X instead of T or Z (the main reason for this is to be consistent with cluster-wise inference which forms clusters based on Z or X)
- enh: improve the thresholding description in the result display 
- enh: add a new function `swe_compareVersions` able to compare versions of the toolbox
- enh: add a (hidden) way to supply a WB resampling matrix instead of letting the toolbox generate one by itself
- enh: add the effective number of degrees of freedom `Approximation I` for the WB
- enh: replace the loop over planes by a loop over chunks of data
- enh: improve the way some X-scores are computed in order to prevent Inf values
- fix: the p-value thresholding is now inclusive for WB analyses
- fix: for WB analyses, the p-values displayed are systematically the WB p-values instead of the parametric p-values
- fix: fix a result display error observed for the classic parametric SwE
- fix: fix some typos
- fix: fix some bugs in the progress display and improve it
- fix: fix several bugs in the result display GUI 

### Link to relevant issues

- Issue #5
- Issue #41
- Issue #102
- Issue #107
- Issue #121 
- Issue #122
- Issue #123
- Issue #124
- Issue #132 

