### PR TITLE
Fix several CIfTI file issues 

### DIFF
--- a/@swe_cifti/private/write_hdr_raw.m
+++ b/@swe_cifti/private/write_hdr_raw.m
@@ -83,6 +83,15 @@ if sts
             sts = false;
         end
     end
+
+    if isfield(hdr, 'ext')
+      % write the XML file
+      fwrite(fp, [1 0 0 0], 'uint8');
+      len1 = fwrite(fp, hdr.ext.esize, 'int32');
+      len2 = fwrite(fp, hdr.ext.ecode, 'int32');
+      len3 = fwrite(fp, hdr.ext.edata, 'char');
+      len4 = fwrite(fp, zeros(1, hdr.ext.esize - 8 - numel(hdr.ext.edata)), 'uint8');
+    end
     fclose(fp);
 end
 

--- a/@swe_cifti/subsasgn.m
+++ b/@swe_cifti/subsasgn.m
@@ -381,8 +381,13 @@ if isa(val,'file_array')
                 obj.hdr.magic = ['n+1' char(0)];
             end
         case {'.dtseries.nii','.dtscalar.nii'}
-            hdr = read_hdr_raw(sval.fname);
-            val.offset    = max(sval.offset, 544 + hdr.ext.esize);
+            if isfield(obj.hdr,'ext')
+              offset = 544 + obj.hdr.ext.esize;
+            else
+              hdr = read_hdr_raw(sval.fname);
+              offset = 544 + hdr.ext.esize;
+            end
+            val.offset    = max(sval.offset, offset);
             obj.hdr.magic = ['n+2' char(0) sprintf('\r\n\032\n')];
         otherwise
             error(['Unknown filename extension (' suf ').']);

--- a/@swe_cifti/subsasgn.m
+++ b/@swe_cifti/subsasgn.m
@@ -379,7 +379,7 @@ if isa(val,'file_array')
                 val.offset    = max(sval.offset,352);
                 obj.hdr.magic = ['n+1' char(0)];
             end
-        case {'.dtseries.nii','.dtscalar.nii'}
+        case {'.dtseries.nii','.dscalar.nii'}
             if isfield(obj.hdr,'ext')
               offset = 544 + obj.hdr.ext.esize;
             else

--- a/@swe_cifti/subsasgn.m
+++ b/@swe_cifti/subsasgn.m
@@ -324,7 +324,6 @@ case {'.'}
             end
 
         case {'hdr'}
-            error('hdr is a read-only field.');
             obj.hdr = val1;
 
         otherwise

--- a/@swe_cifti/subsasgn.m
+++ b/@swe_cifti/subsasgn.m
@@ -363,7 +363,7 @@ if isa(val,'file_array')
         error(['Unknown datatype (' num2str(double(sval.dtype)) ').']);
     end
 
-    [pth,nam,suf] = fileparts(sval.fname);
+    suf = swe_get_file_extension(sval.fname);
     switch suf
         case {'.img','.IMG'}
             val.offset        = max(sval.offset,0);
@@ -380,6 +380,10 @@ if isa(val,'file_array')
                 val.offset    = max(sval.offset,352);
                 obj.hdr.magic = ['n+1' char(0)];
             end
+        case {'.dtseries.nii','.dtscalar.nii'}
+            hdr = read_hdr_raw(sval.fname);
+            val.offset    = max(sval.offset, 544 + hdr.ext.esize);
+            obj.hdr.magic = ['n+2' char(0) sprintf('\r\n\032\n')];
         otherwise
             error(['Unknown filename extension (' suf ').']);
     end

--- a/swe_contrasts.m
+++ b/swe_contrasts.m
@@ -174,7 +174,7 @@ for i = 1:length(Ic)
                                                   metadata);
               %-Write image
               %------------------------------------------------------
-              tmp = NaN(SwE.xVol.DIM');
+              tmp = zeros(SwE.xVol.DIM');
               tmp(Q) = cBeta;
               xCon(ic).Vcon = swe_data_write(xCon(ic).Vcon, tmp);
               
@@ -282,9 +282,9 @@ for i = 1:length(Ic)
 
         str   = 'spm computation';
         swe_progress_bar('Init',100,str,'');
-        equivalentScore = nan(1,S);
+        equivalentScore = zeros(1,S);
         % add output of uncorrected p-values
-        uncP            = nan(1,S);
+        uncP            = zeros(1,S);
         switch(xCon(ic).STAT)
             case 'T'                                 %-Compute spm{t} image
                 %----------------------------------------------------------
@@ -474,9 +474,9 @@ for i = 1:length(Ic)
                     % corrected on 12/05/15 by BG
                     score = score.^2;                 
                 else
-                    score   = nan(1,S);
+                    score   = zeros(1,S);
                     if dof_type ~= 0
-                        edf = nan(1,S);
+                        edf = zeros(1,S);
                     end
                     if dof_type == 2
                         CovcCovBc = 0;
@@ -713,7 +713,7 @@ for i = 1:length(Ic)
                                                 sprintf('SwE effective degrees of freedom - %d: %s',ic,xCon(ic).name),...
                                                 metadata);
 
-            tmp = NaN(SwE.xVol.DIM');
+            tmp = zeros(SwE.xVol.DIM');
             tmp(Q) = edf;
             xCon(ic).Vedf = swe_data_write(xCon(ic).Vedf,tmp);
           end

--- a/swe_cp.m
+++ b/swe_cp.m
@@ -703,7 +703,7 @@ if ~isMat
         %-Estimation of the data variance-covariance components (modified SwE) 
         %-SwE estimation (classic version)
         %--------------------------------------------------------------
-        c = NaN(numel(chunk),1);
+        c = zeros(numel(chunk),1);
 
         if isfield(SwE.type,'modified')
             Cov_vis=zeros(nCov_vis,CrS);
@@ -786,7 +786,7 @@ if ~isMat
 
       %-Write output files
       %======================================================================
-      c = NaN(numel(chunk),1);
+      c = zeros(numel(chunk),1);
 
       %-Write mask file
       %----------------------------------------------------------------------
@@ -979,7 +979,7 @@ else % matrix input
             end
         else % else for "if isfield(SwE.type,'modified')"
             if dof_type == 1 %need to save all subject contributions...
-                crCov_beta_i =  NaN(nSubj,nCov_beta,CrS);
+                crCov_beta_i =  zeros(nSubj,nCov_beta,CrS);
             end
             crCov_beta = 0;
             for i = 1:nSubj
@@ -998,7 +998,7 @@ else % matrix input
             switch dof_type 
                 case 1
                     crCov_beta = zeros(nCov_beta,CrS); % initialize SwE for the plane
-                    crCov_beta_i =  NaN(nGr,nCov_beta,CrS);
+                    crCov_beta_i =  zeros(nGr,nCov_beta,CrS);
                     for g = 1:nGr
                         crCov_beta_i(g,:,:) = weight(:,iGr_Cov_vis_g==g) * crCov_vis(iGr_Cov_vis_g==g,:);                
                         Cov_beta = Cov_beta + crCov_beta_i(g,:,:);
@@ -1018,25 +1018,25 @@ else % matrix input
     save(sprintf('swe_vox_mask%s',file_ext), 'mask');
     clear mask
 
-    beta = NaN(nBeta, nVox);
+    beta = zeros(nBeta, nVox);
     beta(:,cmask) = crBeta;
     save(sprintf('swe_vox_beta_b%s',file_ext), 'beta');
     clear beta crBeta
 
     if isfield(SwE.type,'modified')
-        cov_vis = NaN(nCov_vis, nVox);
+        cov_vis = zeros(nCov_vis, nVox);
         cov_vis(:,cmask) = crCov_vis;
         save(sprintf('swe_vox_cov_vv%s',file_ext), 'cov_vis');
         clear cov_vis crCov_vis
     end
 
-    cov_beta = NaN(nCov_beta, nVox);
+    cov_beta = zeros(nCov_beta, nVox);
     cov_beta(:,cmask) = crCov_beta;
     save(sprintf('swe_vox_cov%s',file_ext), 'cov_beta');
     clear cov_beta crCov_beta
     if dof_type == 1
         nGr = nSubj;
-        cov_beta_g = NaN(nGr, nCov_beta, nVox);
+        cov_beta_g = zeros(nGr, nCov_beta, nVox);
         cov_beta_g(:,:,cmask) = crCov_beta_i;
         save(sprintf('swe_vox_cov_g_bb%s',file_ext), 'cov_beta_g');
         clear cov_beta_g crCov_beta_i

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1067,7 +1067,7 @@ if ~isMat
 
     %-Write output files
     %======================================================================
-    c = NaN(numel(chunk),1);
+    c = zeros(numel(chunk),1);
 
       %-Write mask file
     %----------------------------------------------------------------------
@@ -1529,7 +1529,7 @@ else % ".mat" format
   clear Vedf
   
   tmp = score;
-  score = nan(1, nVox);
+  score = zeros(1, nVox);
   if (SwE.WB.stat == 'T')
     VT(:,cmask) = tmp;
     save(Vscore, 'VT');
@@ -1542,26 +1542,26 @@ else % ".mat" format
     clear tmp VF
   end
   
-  VlP = nan(1, nVox);
+  VlP = zeros(1, nVox);
   VlP(:,cmask) = -log10(hyptest.positive.p);
   save(sprintf('swe_vox_%cstat_lp_c%02d%s', WB.stat, 1, file_ext), 'VlP');
   clear VlP
   
   if (SwE.WB.stat == 'T')
     
-    VlP_neg = nan(1, nVox);
+    VlP_neg = zeros(1, nVox);
     VlP_neg(:,cmask) =  -log10(hyptest.negative.p);
     save(sprintf('swe_vox_%cstat_lp_c%02d%s', WB.stat, 2, file_ext), 'VlP_neg');
     clear VlP_neg
     
-    z_map = nan(1, nVox);
+    z_map = zeros(1, nVox);
     VZ(:,cmask) =  hyptest.positive.conScore;
     save(sprintf('swe_vox_z%cstat_c%02d%s', WB.stat, 1, file_ext), 'VZ');
     clear VZ
     
   else
       
-    x_map = nan(1, nVox);
+    x_map = zeros(1, nVox);
     VX(:,cmask) =  hyptest.positive.conScore;
     save(sprintf('swe_vox_x%cstat_c%02d%s', WB.stat, 1, file_ext), 'VX');
     clear VX
@@ -2428,7 +2428,7 @@ end
 %==========================================================================
 if isMat
   uncP = uncP / (WB.nB + 1);
-  uncP_pos = nan(1, nVox);
+  uncP_pos = zeros(1, nVox);
   uncP_pos(:,cmask) = uncP;
   VlP_wb_pos = -log10(uncP);
   save(sprintf('swe_vox_%cstat_lp-WB_c%02d%s', WB.stat, 1, file_ext), 'VlP_wb_pos');
@@ -2466,7 +2466,7 @@ if isMat
     FWERP = FWERP + (maxScore(b+1) > originalScore - tol);
   end
   FWERP = FWERP / (WB.nB + 1);
-  fwerP_pos = nan(1, nVox);
+  fwerP_pos = zeros(1, nVox);
   fwerP_pos(:,cmask) = FWERP;
   VlP_wb_FWE_pos = -log10(fwerP_pos);
   save(sprintf('swe_vox_%cstat_lpFWE-WB_c%02d%s',WB.stat,1,file_ext), 'VlP_wb_FWE_pos');
@@ -2484,7 +2484,7 @@ if isMat
       FWERPNeg = FWERPNeg + (minScore(b+1) < originalScore + tol);
     end
     FWERPNeg = FWERPNeg / (WB.nB + 1);
-    fwerP_neg = nan(1, nVox);
+    fwerP_neg = zeros(1, nVox);
     fwerP_neg(:,cmask) = FWERPNeg;
     VlP_wb_FWE_neg = -log10(fwerP_neg);
     save(sprintf('swe_vox_%cstat_lpFWE-WB_c%02d%s',WB.stat,2,file_ext), 'VlP_wb_FWE_neg');
@@ -2499,7 +2499,7 @@ if isMat
   catch
     fdrP = spm_P_FDR(uncP,[],'P',[],sort(uncP)');
   end
-  fdrP_pos = nan(1, nVox);
+  fdrP_pos = zeros(1, nVox);
   fdrP_pos(:,cmask) = fdrP;
   VlP_wb_FDR_pos = -log10(fdrP_pos);
   save(sprintf('swe_vox_%cstat_lpFDR-WB_c%02d%s',WB.stat,1,file_ext), 'VlP_wb_FDR_pos');
@@ -2511,7 +2511,7 @@ if isMat
     catch
       fdrP = spm_P_FDR(1 + 1/(WB.nB + 1) - uncP,[],'P',[],sort(1 + 1/(WB.nB + 1) - uncP)');
     end
-    fdrP_neg = nan(1, nVox);
+    fdrP_neg = zeros(1, nVox);
     fdrP_neg(:,cmask) = fdrP;
     VlP_wb_FDR_neg = -log10(fdrP_neg);
     save(sprintf('swe_vox_%cstat_lpFDR-WB_c%02d%s',WB.stat,2,file_ext), 'VlP_wb_FDR_neg');
@@ -2531,7 +2531,7 @@ if isMat
       clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster / (WB.nB + 1);
     end
     
-    clusterFwerP_pos_perElement = nan(1, nVox);
+    clusterFwerP_pos_perElement = zeros(1, nVox);
     if ~isMat || isfield(SwE.WB.clusterInfo, 'Vxyz')      
       tmp = find(cmask);
       tmp3 = zeros(1, size(SwE.WB.clusterInfo.LocActivatedVoxels,2));
@@ -2559,7 +2559,7 @@ if isMat
         clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster / (WB.nB + 1);
       end
       
-      clusterFwerP_neg_perElement = nan(1, nVox);
+      clusterFwerP_neg_perElement = zeros(1, nVox);
       if ~isMat || isfield(SwE.WB.clusterInfo, 'Vxyz')
         tmp = find(cmask);
         tmp3 = zeros(1, size(SwE.WB.clusterInfo.LocActivatedVoxelsNeg,2));
@@ -2586,12 +2586,12 @@ else
   % - write out lP+ and lP- images;
   %
   uncP = uncP / (WB.nB + 1);
-  tmp = nan(SwE.xVol.DIM');
+  tmp = zeros(SwE.xVol.DIM');
   tmp(Q) = -log10(uncP);
   swe_data_write(VlP_wb_pos, tmp);
   
   % If it's F, write out an X map.
-  stat = nan(SwE.xVol.DIM');
+  stat = zeros(SwE.xVol.DIM');
   if WB.stat == 'F'
     stat(Q) = spm_invXcdf(1 - uncP,1);
     swe_data_write(VcScore_wb_pos, stat);
@@ -2700,7 +2700,7 @@ else
     % voxels after the thresholding of the original data
     Q = cumprod([1,SwE.xVol.DIM(1:2)']) * SwE.WB.clusterInfo.LocActivatedVoxels - ...
   	  sum(cumprod(SwE.xVol.DIM(1:2)'));
-    tmp= nan(SwE.xVol.DIM');
+    tmp= zeros(SwE.xVol.DIM');
     
     clusterFwerP_pos_perCluster = ones(1, SwE.WB.clusterInfo.nCluster); % 1 because the original maxScore is always > original Score
     if (~isempty(SwE.WB.clusterInfo.clusterSize))
@@ -2760,7 +2760,7 @@ else
     if WB.stat =='T'
       Q = cumprod([1,SwE.xVol.DIM(1:2)']) * SwE.WB.clusterInfo.LocActivatedVoxelsNeg - ...
 	      sum(cumprod(SwE.xVol.DIM(1:2)'));
-      tmp= nan(SwE.xVol.DIM');
+      tmp= zeros(SwE.xVol.DIM');
       
       clusterFwerP_neg_perCluster = ones(1, SwE.WB.clusterInfo.nClusterNeg); % 1 because the original maxScore is always > original Score
       if (~isempty(SwE.WB.clusterInfo.clusterSizeNeg))

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -2428,24 +2428,26 @@ end
 %==========================================================================
 if isMat
   uncP = uncP / (WB.nB + 1);
-  uncP_pos = zeros(1, nVox);
-  uncP_pos(:,cmask) = uncP;
-  VlP_wb_pos = -log10(uncP);
+  VlP_wb_pos = zeros(1, nVox);
+  VlP_wb_pos(:,cmask) = -log10(uncP);
   save(sprintf('swe_vox_%cstat_lp-WB_c%02d%s', WB.stat, 1, file_ext), 'VlP_wb_pos');
   clear VlP_wb_pos
   
   if WB.stat == 'T'
-    uncP_neg = 1 + 1/(WB.nB + 1) - uncP_pos;
-    VlP_wb_neg = -log10(uncP_neg);
+    uncP_neg = 1 + 1/(WB.nB + 1) - uncP;
+    VlP_wb_neg = zeros(1, nVox);
+    VlP_wb_neg(:,cmask) = -log10(uncP_neg);
     save(sprintf('swe_vox_%cstat_lp-WB_c%02d%s', WB.stat, 2, file_ext), 'VlP_wb_neg');
     clear VlP_wb_neg
     
-    VZ_wb = swe_invNcdf(1 - uncP);
+    VZ_wb = zeros(1, nVox);
+    VZ_wb(:,cmask) = swe_invNcdf(1 - uncP);
     save(sprintf('swe_vox_z%cstat-WB_c%02d%s', WB.stat, 1, file_ext), 'VZ_wb');
     clear VZ_wb
     
   else
-      
+    
+    VX_wb = zeros(1, nVox);
     VX_wb = spm_invXcdf(1 - uncP,1);
     save(sprintf('swe_vox_x%cstat-WB_c%02d%s', WB.stat, 1, file_ext), 'VX_wb');
     clear VX_wb
@@ -2466,9 +2468,8 @@ if isMat
     FWERP = FWERP + (maxScore(b+1) > originalScore - tol);
   end
   FWERP = FWERP / (WB.nB + 1);
-  fwerP_pos = zeros(1, nVox);
-  fwerP_pos(:,cmask) = FWERP;
-  VlP_wb_FWE_pos = -log10(fwerP_pos);
+  VlP_wb_FWE_pos = zeros(1, nVox);
+  VlP_wb_FWE_pos(:,cmask) = -log10(FWERP);
   save(sprintf('swe_vox_%cstat_lpFWE-WB_c%02d%s',WB.stat,1,file_ext), 'VlP_wb_FWE_pos');
   clear VlP_wb_FWE_pos fwerP_pos FWERP
   
@@ -2484,9 +2485,8 @@ if isMat
       FWERPNeg = FWERPNeg + (minScore(b+1) < originalScore + tol);
     end
     FWERPNeg = FWERPNeg / (WB.nB + 1);
-    fwerP_neg = zeros(1, nVox);
-    fwerP_neg(:,cmask) = FWERPNeg;
-    VlP_wb_FWE_neg = -log10(fwerP_neg);
+    VlP_wb_FWE_neg = zeros(1, nVox);
+    VlP_wb_FWE_neg(:,cmask) = -log10(FWERPNeg);
     save(sprintf('swe_vox_%cstat_lpFWE-WB_c%02d%s',WB.stat,2,file_ext), 'VlP_wb_FWE_neg');
     clear VlP_wb_FWE_neg fwerP_neg
   end
@@ -2499,9 +2499,8 @@ if isMat
   catch
     fdrP = spm_P_FDR(uncP,[],'P',[],sort(uncP)');
   end
-  fdrP_pos = zeros(1, nVox);
-  fdrP_pos(:,cmask) = fdrP;
-  VlP_wb_FDR_pos = -log10(fdrP_pos);
+  VlP_wb_FDR_pos = zeros(1, nVox);
+  VlP_wb_FDR_pos(:,cmask) = -log10(fdrP);
   save(sprintf('swe_vox_%cstat_lpFDR-WB_c%02d%s',WB.stat,1,file_ext), 'VlP_wb_FDR_pos');
   clear VlP_wb_FDR_pos fdrP_pos fdrP
   
@@ -2511,9 +2510,8 @@ if isMat
     catch
       fdrP = spm_P_FDR(1 + 1/(WB.nB + 1) - uncP,[],'P',[],sort(1 + 1/(WB.nB + 1) - uncP)');
     end
-    fdrP_neg = zeros(1, nVox);
-    fdrP_neg(:,cmask) = fdrP;
-    VlP_wb_FDR_neg = -log10(fdrP_neg);
+    VlP_wb_FDR_neg = zeros(1, nVox);
+    VlP_wb_FDR_neg(:,cmask) = -log10(fdrP);
     save(sprintf('swe_vox_%cstat_lpFDR-WB_c%02d%s',WB.stat,2,file_ext), 'VlP_wb_FDR_neg');
     clear VlP_wb_FDR_neg fdrP_neg fdrP
   end
@@ -2531,22 +2529,21 @@ if isMat
       clusterFwerP_pos_perCluster = clusterFwerP_pos_perCluster / (WB.nB + 1);
     end
     
-    clusterFwerP_pos_perElement = zeros(1, nVox);
+    VlP_wb_clusterFWE_pos = zeros(1, nVox);
     if ~isMat || isfield(SwE.WB.clusterInfo, 'Vxyz')      
       tmp = find(cmask);
       tmp3 = zeros(1, size(SwE.WB.clusterInfo.LocActivatedVoxels,2));
       for iC = 1:SwE.WB.clusterInfo.nCluster
         tmp3(SwE.WB.clusterInfo.clusterAssignment == iC) = clusterFwerP_pos_perCluster(iC);
       end
-      clusterFwerP_pos_perElement(tmp(activatedVoxels)) = tmp3;
+      VlP_wb_clusterFWE_pos(tmp(activatedVoxels)) = -log10(tmp3);
     else
       tmp3 = zeros(1, sum(SwE.WB.clusterInfo.LocActivatedVoxels));
       for iC = 1:SwE.WB.clusterInfo.nCluster
         tmp3(SwE.WB.clusterInfo.clusterAssignment == iC) = clusterFwerP_pos_perCluster(iC);
       end
-      clusterFwerP_pos_perElement(SwE.WB.clusterInfo.LocActivatedVoxels) = tmp3;
+      VlP_wb_clusterFWE_pos(SwE.WB.clusterInfo.LocActivatedVoxels) = -log10(tmp3);
     end
-    VlP_wb_clusterFWE_pos  = -log10(clusterFwerP_pos_perElement);
     save(sprintf('swe_clustere_%cstat_lpFWE-WB_c%02d%s',WB.stat,1,file_ext), 'VlP_wb_clusterFWE_pos');
     
     if WB.stat =='T'
@@ -2559,22 +2556,21 @@ if isMat
         clusterFwerP_neg_perCluster = clusterFwerP_neg_perCluster / (WB.nB + 1);
       end
       
-      clusterFwerP_neg_perElement = zeros(1, nVox);
+      VlP_wb_clusterFWE_neg = zeros(1, nVox);
       if ~isMat || isfield(SwE.WB.clusterInfo, 'Vxyz')
         tmp = find(cmask);
         tmp3 = zeros(1, size(SwE.WB.clusterInfo.LocActivatedVoxelsNeg,2));
         for iC = 1:SwE.WB.clusterInfo.nClusterNeg
           tmp3(SwE.WB.clusterInfo.clusterAssignmentNeg == iC) = clusterFwerP_neg_perCluster(iC);
         end
-      clusterFwerP_neg_perElement(tmp(activatedVoxelsNeg)) = tmp3;
+      VlP_wb_clusterFWE_neg(tmp(activatedVoxelsNeg)) = -log10(tmp3);
       else
         tmp3 = zeros(1, sum(SwE.WB.clusterInfo.LocActivatedVoxelsNeg));
         for iC = 1:SwE.WB.clusterInfo.nClusterNeg
           tmp3(SwE.WB.clusterInfo.clusterAssignmentNeg == iC) = clusterFwerP_neg_perCluster(iC);
         end
-        clusterFwerP_neg_perElement(SwE.WB.clusterInfo.LocActivatedVoxelsNeg) = tmp3;
+        VlP_wb_clusterFWE_neg(SwE.WB.clusterInfo.LocActivatedVoxelsNeg) = -log10(tmp3);
       end
-      VlP_wb_clusterFWE_neg  = -log10(clusterFwerP_neg_perElement);
       save(sprintf('swe_clustere_%cstat_lpFWE-WB_c%02d%s',WB.stat,2,file_ext), 'VlP_wb_clusterFWE_neg');
     end
   end

--- a/swe_data_hdr_read.m
+++ b/swe_data_hdr_read.m
@@ -1,4 +1,4 @@
-function V = swe_data_hdr_read(P)
+function V = swe_data_hdr_read(P, varargin)
   % Read data information from file(s)
   % FORMAT V = spm_data_hdr_read(P)
   % P        - a char or cell array of filenames
@@ -12,6 +12,13 @@ function V = swe_data_hdr_read(P)
   P2 = cellstr(P);
   file_ext = swe_get_file_extension(P2{1});
   isCifti  = strcmpi(file_ext,'.dtseries.nii') ||  strcmpi(file_ext,'.dscalar.nii');
+
+  if nargin > 1
+    readExt = varargin{1};
+  else
+    readExt = false;
+  end
+
   if isCifti
     it = 1;
     for i=1:numel(P2)
@@ -25,7 +32,7 @@ function V = swe_data_hdr_read(P)
         P2{i} = P2{i}(1:(end-numel(sliceInd)));
       end
       
-      ciftiObject = swe_cifti(P2{i}, false);
+      ciftiObject = swe_cifti(P2{i}, readExt);
       
       if isempty(sliceInd)
         sliceInd = 1:ciftiObject.dat.dim(5);

--- a/swe_data_hdr_write.m
+++ b/swe_data_hdr_write.m
@@ -34,11 +34,11 @@ function V = swe_data_hdr_write(fname, DIM, M, descrip, metadata, varargin)
     else
       sourceName = V.ciftiTemplate(1:( end - numel(sliceInd) ));
     end
+    
     % make sure we select only one slice
-    copyfile(sourceName, fname);
-    V = swe_data_hdr_read(fname);
+    V = swe_data_hdr_read(sprintf('%s,1', sourceName), true);
+
     V.fname = fname;
-    V.descrip = descrip;
     V.private.dat.fname = fname;
     V.private.dat = file_array(fname,...
                                  [1,1,1,1,1,V.dim(1)],...
@@ -46,7 +46,12 @@ function V = swe_data_hdr_write(fname, DIM, M, descrip, metadata, varargin)
                                  0,...
                                  1,...
                                  0);
-    V.private.dat(:) = NaN;
+    V.n = [1 1];
+    
+    create(V.private)    
+    V.private.dat(:) = 0;
+    V = swe_data_hdr_read(fname, false);
+    V.descrip = descrip;
   else
     V = spm_data_hdr_write(V);
   end

--- a/swe_data_hdr_write.m
+++ b/swe_data_hdr_write.m
@@ -47,6 +47,17 @@ function V = swe_data_hdr_write(fname, DIM, M, descrip, metadata, varargin)
                                  1,...
                                  0);
     V.n = [1 1];
+    % modify the xml if the number of point is > 1 
+    xml = char(V.private.hdr.ext.edata(:)');
+    ind = strfind(xml, 'NumberOfSeriesPoints="');
+    if ~isempty(ind)
+      ind  = ind  + numel('NumberOfSeriesPoints="');
+      xml(ind) = '1';
+      while ~strcmp(xml(ind+1), '"')
+        xml(ind+1) = [];
+      end
+    end
+    V.private.hdr.ext.edata = uint8(xml)';
     
     create(V.private)    
     V.private.dat(:) = 0;

--- a/swe_data_hdr_write.m
+++ b/swe_data_hdr_write.m
@@ -35,7 +35,8 @@ function V = swe_data_hdr_write(fname, DIM, M, descrip, metadata, varargin)
       sourceName = V.ciftiTemplate(1:( end - numel(sliceInd) ));
     end
     % make sure we select only one slice
-    V = swe_data_hdr_read(sprintf('%s,1',sourceName));
+    copyfile(sourceName, fname);
+    V = swe_data_hdr_read(fname);
     V.fname = fname;
     V.descrip = descrip;
     V.private.dat.fname = fname;
@@ -46,10 +47,8 @@ function V = swe_data_hdr_write(fname, DIM, M, descrip, metadata, varargin)
                                  1,...
                                  0);
     V.private.dat(:) = NaN;
-    create(V.private);
   else
     V = spm_data_hdr_write(V);
   end
       
 end
-  

--- a/swe_thresholdImage.m
+++ b/swe_thresholdImage.m
@@ -55,7 +55,7 @@ function swe_thresholdImage(threshold, minimumClusterSize)
 
   end
 
-  tmp= nan(VI.dim);
+  tmp= zeros(VI.dim);
   Q = cumprod([1,VI.dim(1:2)])*XYZ - ...
     sum(cumprod(VI.dim(1:2)));
   tmp(Q) = Z;

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -171,9 +171,9 @@ function mapsEqual = verifyMapsUnchanged(porwb, inftype, torf, matorimg)
 
 		end
 
-		% Remove NaN values
-		file = file(~isnan(file));
-		gt_file = gt_file(~isnan(gt_file));
+		% Remove NaN and zero values
+		file = file(~isnan(file) & file ~= 0);
+		gt_file = gt_file(~isnan(gt_file) & gt_file ~= 0);
 		
 		% Check whether the remaining values are equal.
 		%


### PR DESCRIPTION
The goal of this PR is to fix some issues observed with CIfTI files. Here below a summary of the fixes:

1. The XML files of the CIfTI inputs are now always copied in the CIfTI outputs. Before this PR, that was not the case.
2. The XML files of the CIfTI inputs with more than one contrast are modified in the outputs to set the number of time series to 1 (i.e. NumberOfSeriesPoints="1")
3. the nan values in the outputs have been replaced by zero values to avoid issues with CIFTI files