### PR TITLE
New release 2.2.0.rc2

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -11,7 +11,7 @@ function varargout = swe(varargin)
 % Written by Bryan Guillaume
 % Version Info:  $Format:%ci$ $Format:%h$
 
-versionNo = '2.2.0.rc';
+versionNo = '2.2.0.rc2';
 
 try
   Modality = spm_get_defaults('modality');

--- a/swe.m
+++ b/swe.m
@@ -59,7 +59,9 @@ switch lower(Action)
         %==================================================================
     case 'asciiwelcome'                          %-ASCII swe banner welcome
         %==================================================================
-        a = generateAscii(['SwE v' replace(versionNo,'.rc','')]);
+        tmp = replace(versionNo,'.rc2','');
+        tmp = replace(tmp,'.rc','');
+        a = generateAscii(['SwE v' tmp]);
         fprintf('%s \n', a{1}, a{2}, a{3}, a{4});
         fprintf('swe v%s \n', versionNo);
   

--- a/swe_checkCompat.m
+++ b/swe_checkCompat.m
@@ -46,7 +46,8 @@ function swe_checkCompat(matVer, tbVer)
     earliestCompatVer('2.1.0') = '2.0.0';
     earliestCompatVer('2.1.1') = '2.0.0';
     earliestCompatVer('2.2.0.rc') = '2.0.0';
- 
+    earliestCompatVer('2.2.0.rc2') = '2.0.0';
+
     % The below line works out the latest compatible version from the
     % earliest compatible versions. This code is now redundant but may be
     % useful in future so has been left in place. Tom Maullin (09/11/2018)


### PR DESCRIPTION
### Changes made since the previous version

- fix: ensure that each CIfTI outputs contain an appropriate CIfTI XML file
- fix: replace the nan values in output files by zero values (this is to avoid issues when reading the CIfTI outputs in other software packages)