### PR TITLE
Keep only one "NamedMap" in the XML of the SwE dscalar.nii outputs

### DIFF
--- a/swe_data_hdr_write.m
+++ b/swe_data_hdr_write.m
@@ -57,6 +57,21 @@ function V = swe_data_hdr_write(fname, DIM, M, descrip, metadata, varargin)
         xml(ind+1) = [];
       end
     end
+
+    % modify the xml if there is more than one <NamedMap>
+    ind = strfind(xml, '<NamedMap>');
+    if numel(ind > 1)
+      ind2 = strfind(xml,'</NamedMap>');
+      sliceInd = str2num(sliceInd);
+      % remove the <NamedMap>'s after the selected slice unless this is the last
+      if sliceInd ~= numel(ind)
+        xml(ind(sliceInd+1):(ind2(end) + numel('</NamedMap>'))) = [];
+      end
+      % remove the <NamedMap>'s before the selected slice unless this is the first
+      if sliceInd ~= 1
+        xml(ind(1):(ind2(sliceInd-1) + numel('</NamedMap>'))) = [];
+      end
+    end
     V.private.hdr.ext.edata = uint8(xml)';
     
     create(V.private)    


### PR DESCRIPTION
The goal of this PR is to keep only one "NamedMap" in the XML extension of the toolbox dscalar.nii outputs.

The code change seems to work as can be seen in the screenshot below. However, the "NamedMap" that is kept (i.e. WM_15_BODY) corresponds to the "NamedMap" of the slice selected for the first dscalar.nii input. As, in an analysis, other slices could be selected as well (in this specific analysis, I was using 4 different slices), that might not be so great. Another solution would be to write a specific name for the swE output like "SWE_OUTPUT" to avoid confusion. @nicholst, do you think this is an issue worth to be worried about? 

<img width="862" alt="Screenshot 2019-10-31 at 20 30 42" src="https://user-images.githubusercontent.com/4426961/68020248-33774e80-fc9e-11e9-902c-52e1186cc6f9.png">
