### PR TITLE
Fix several bugs related to the naive estimation of edf

### DIFF
--- a/swe_contrasts.m
+++ b/swe_contrasts.m
@@ -242,8 +242,13 @@ for i = 1:length(Ic)
         if dof_type == 1
             cCovBc_g = zeros(nSizeCon*(nSizeCon+1)/2,S,SwE.Gr.nGr);
         else
-            xCon(ic).edf = sum(SwE.dof.nSubj_dof(unique(SwE.dof.iBeta_dof(ind))) - ...
-            SwE.dof.pB_dof(unique(SwE.dof.iBeta_dof(ind)))); 
+            indSubDesignMatrices = SwE.dof.iBeta_dof(ind);
+            subjectsInvolved = [];
+            for iIndSubDesignMatrices = indSubDesignMatrices
+              subjectsInvolved = [subjectsInvolved; SwE.Subj.iSubj(SwE.dof.iGr_dof == iIndSubDesignMatrices)];
+            end
+            subjectsInvolved = unique(subjectsInvolved);
+            xCon(ic).edf = sum(SwE.dof.edof_Subj(subjectsInvolved));
         end
         
         % load .mat file(s) if this is the format

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -346,8 +346,14 @@ if dof_type == 0 % so naive estimation is used
   else
     ind = find(any(conWB~=0));
   end
-  edf = sum(nSubj_dof(unique(iBeta_dof(ind))) - pB_dof(unique(iBeta_dof(ind))));
-  
+  indSubDesignMatrices = iBeta_dof(ind);
+  subjectsInvolved = [];
+  for iIndSubDesignMatrices = indSubDesignMatrices
+    subjectsInvolved = [subjectsInvolved; iSubj(iGr_dof == iIndSubDesignMatrices)];
+  end
+  subjectsInvolved = unique(subjectsInvolved);
+  edf = sum(edof_Subj(subjectsInvolved));
+
   dof_cov = zeros(1,nBeta);
   for i = 1:nBeta
     dof_cov(i) = nSubj_dof(iBeta_dof(i)) - ...

--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -1397,12 +1397,6 @@ if isfield(SwE.type, 'modified')
     xSwE.min_nVis_g = SwE.Vis.min_nVis_g;
 end
 
-if dof_type == 0
-  xSwE.edf = xCon(Ic).edf;
-else
-  xSwE.Vedf = cat(1,xCon(Ic).Vedf);
-end
-
 % For WB analyses we have already computed uncorrected, FDR, FWE and
 % cluster-FWE P values at this point.
 if isfield(SwE, 'WB')
@@ -1499,7 +1493,12 @@ if isfield(SwE, 'WB')
     
     % edf
     xSwE.Vedf       = cat(1,xCon(Ic).Vedf);
-    
+  else
+    if dof_type == 0
+      xSwE.edf = xCon(Ic).edf;
+    else
+      xSwE.Vedf = cat(1,xCon(Ic).Vedf);
+    end    
 end
 
 % Record clusterwise FWE P value if there is one.


### PR DESCRIPTION
The goal of the PR is to fix the 2 issues #153 and #154.

To fix issue #153, the piece of code throwing the error has been moved in an if/else statement to ensure it is only visited for parametric analyses.

To fix issue #154, the toolbox is now detecting which subjects are involved in the contrast tested and compute the naive edf based on these subjects. This seems to fix the observed issue.