### PR TITLE
Fix a bug in the naive computation of the effective number of degrees of freedom

### DIFF
--- a/swe_contrasts.m
+++ b/swe_contrasts.m
@@ -248,7 +248,12 @@ for i = 1:length(Ic)
               subjectsInvolved = [subjectsInvolved; SwE.Subj.iSubj(SwE.dof.iGr_dof == iIndSubDesignMatrices)];
             end
             subjectsInvolved = unique(subjectsInvolved);
-            xCon(ic).edf = sum(SwE.dof.edof_Subj(subjectsInvolved));
+            indSubjInvolved = nan(length(subjectsInvolved),1);
+            % convert into in
+            for iSubjInvolved = 1:length(subjectsInvolved)
+              indSubjInvolved(iSubjInvolved) = find(SwE.Subj.uSubj == subjectsInvolved(iSubjInvolved));
+            end
+            xCon(ic).edf = sum(SwE.dof.edof_Subj(indSubjInvolved));
         end
         
         % load .mat file(s) if this is the format

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -352,7 +352,12 @@ if dof_type == 0 % so naive estimation is used
     subjectsInvolved = [subjectsInvolved; iSubj(iGr_dof == iIndSubDesignMatrices)];
   end
   subjectsInvolved = unique(subjectsInvolved);
-  edf = sum(edof_Subj(subjectsInvolved));
+  indSubjInvolved = nan(length(subjectsInvolved),1);
+  % convert into in
+  for iSubjInvolved = 1:length(subjectsInvolved)
+    indSubjInvolved(iSubjInvolved) = find(uSubj == subjectsInvolved(iSubjInvolved));
+  end
+  edf = sum(edof_Subj(indSubjInvolved));
 
   dof_cov = zeros(1,nBeta);
   for i = 1:nBeta


### PR DESCRIPTION
The goal of this PR is to fix a bug introduced in PR #155 regarding the computation of the naive estimation of the effective number of degrees of freedom.

The labels of the subjects that were involved in the contrast tested were not converted into indices prior to computing the naive edf. During the testing of the previous PR, the labels were actually matching the indices and the bug was not caught at that time.