### PR TITLE
Release SwE Version 2.2.0

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -11,7 +11,7 @@ function varargout = swe(varargin)
 % Written by Bryan Guillaume
 % Version Info:  $Format:%ci$ $Format:%h$
 
-versionNo = '2.2.0.rc2';
+versionNo = '2.2.0';
 
 try
   Modality = spm_get_defaults('modality');

--- a/swe_checkCompat.m
+++ b/swe_checkCompat.m
@@ -47,6 +47,7 @@ function swe_checkCompat(matVer, tbVer)
     earliestCompatVer('2.1.1') = '2.0.0';
     earliestCompatVer('2.2.0.rc') = '2.0.0';
     earliestCompatVer('2.2.0.rc2') = '2.0.0';
+    earliestCompatVer('2.2.0') = '2.0.0';
 
     % The below line works out the latest compatible version from the
     % earliest compatible versions. This code is now redundant but may be


### PR DESCRIPTION
### Changes made since the previous version (v2.1.1)

- enh: add GIfTI support
- enh: add CIfTI support
- enh: all the non-parametric WB p-values are now computed using a tolerance of 10^-8 for comparing real numbers
- enh: the maximum TFCE scores are now saved into SwE.mat
- enh: the WB procedure now makes voxel-wise inference on Z or X instead of T or Z (the main reason for this is to be consistent with cluster-wise inference which forms clusters based on Z or X)
- enh: improve the thresholding description in the result display 
- enh: add a new function `swe_compareVersions` able to compare versions of the toolbox
- enh: add a (hidden) way to supply a WB resampling matrix instead of letting the toolbox generate one by itself
- enh: add the effective number of degrees of freedom `Approximation I` for the WB
- enh: replace the loop over planes by a loop over chunks of data
- enh: improve the way some X-scores are computed in order to prevent Inf values
- enh: add the option to constrain volume clusters to be within the ROI boundaries in CIfTI analyses 
- enh: modify the naming convention for CIfTI, GIfTI and .mat outputs to better match PALM naming convention
- fix: the p-value thresholding is now inclusive for WB analyses
- fix: for WB analyses, the p-values displayed are systematically the WB p-values instead of the parametric p-values
- fix: fix a result display error observed for the classic parametric SwE
- fix: fix some typos
- fix: fix some bugs in the progress display and improve it
- fix: fix several bugs in the result display GUI 
- fix: ensure that each CIfTI outputs contain an appropriate CIfTI XML file
- fix: replace the nan values in output files by zero values (this is to avoid issues when reading the CIfTI outputs in other software packages)
- fix: keep only one "NameMap" in the XML extension of the toolbox dscalar.nii outputs
- fix: fix bugs related to zeroing nan values
- fix: fix several bugs related to the naive estimation of the effective number of degrees of freedom
- fix: fix a bug in the detection of sub-design matrices
- fix: fix a bug where some ROI volume labels with multiple 'V_'  would not be processed correctly

### Link to relevant issues

- Issue #5
- Issue #41
- Issue #102
- Issue #107
- Issue #121 
- Issue #122
- Issue #123
- Issue #124
- Issue #132 
- issue #140
- issue #148
- issue #150
- issue #153 
- issue #154
- issue #156