### PR TITLE
Avoid chaining calls to 'subsasgn' when writing by indices GIfTI files in Octave

### DIFF
--- a/swe_data_write.m
+++ b/swe_data_write.m
@@ -30,6 +30,15 @@ function V = swe_data_write(V, Y, varargin)
         V.private.dat(varargin{1}) = reshape(Y,size(varargin{1}))';
       end
     end
+  elseif strcmpi(cl, 'gifti') && ~isempty(varargin) && exist('OCTAVE_VERSION','builtin') 
+    D = V.private.private.data{1};
+    tmp = reshape(Y,size(varargin{1}));
+    try
+      D.data(varargin{1}) = tmp;
+    catch
+      D.data(varargin{1}) = tmp';
+    end
+    V.private.private.data{1} = D;
   else
     V = spm_data_write(V, Y, varargin{:});
   end


### PR DESCRIPTION
The goal of this PR is to circumvent the bug in Octave reported in issue  #163.

This is simply done by detecting in `swe_data_write` that we are trying to write a GIfTI file by indices in Octave. If this is the case, we do not call `spm_data_write` to do it, but we explicitly write the data in two steps, preventing `spm_data_write` to chain two calls of `subsasgn`.

Testing it on my computer in an octave environment seems to fix the issue.

