### PR TITLE
Replace double quotation syntax by simple quotation syntax

### DIFF
--- a/swe_getSPM.m
+++ b/swe_getSPM.m
@@ -938,7 +938,7 @@ if ~isMat
                   elseif Ic == 2
                     maxScore = sort(-SwE.WB.minScore);
                   else
-                    error("Unknown contrast");
+                    error('Unknown contrast');
                   end
                   u = maxScore( ceil( (1-pu) * (SwE.WB.nB+1) ) );
 
@@ -1037,7 +1037,7 @@ if ~isMat
                   elseif Ic == 2
                     locActVox = SwE.WB.clusterInfo.LocActivatedVoxelsNeg;
                   else
-                    error("Unknown contrast");
+                    error('Unknown contrast');
                   end
                   [~, index]=ismember(XYZ',locActVox','rows');
                   Q=find(index~=0);
@@ -1297,7 +1297,7 @@ if ~isMat
                   maxClusterSize = SwE.WB.clusterInfo.maxClusterSizeNeg;
                 end
               else
-                error("unknown contrast");
+                error('Unknown contrast');
               end
               
               ps_fwe = nan(1,numel(A));
@@ -1477,7 +1477,7 @@ if isfield(SwE, 'WB')
     elseif Ic == 2
       maxScore = sort(-SwE.WB.minScore);
     else
-      error("Unknown contrast");
+      error('Unknown contrast');
     end
     xSwE.Pfv = maxScore(ceil(0.95*(xSwE.nB+1))); % Voxelwise FWE P 
     if SwE.WB.clusterWise
@@ -1486,7 +1486,7 @@ if isfield(SwE, 'WB')
       elseif Ic == 2
         maxClusterSize = sort(SwE.WB.clusterInfo.maxClusterSizeNeg);
       else
-        error("Unknown contrast");
+        error('Unknown contrast');
       end
       xSwE.Pfc = maxClusterSize(ceil(0.95*(xSwE.nB+1))); % Clusterwise FWE P      
     end

--- a/swe_results_ui.m
+++ b/swe_results_ui.m
@@ -287,7 +287,7 @@ switch lower(Action), case 'setup'                         %-Set up results
 
     if isCifti
       DIM(3) = Inf;
-      strDataType = "voxels/vertices";
+      strDataType = 'voxels/vertices';
     end
 
     %-Space units

--- a/test/runTest.m
+++ b/test/runTest.m
@@ -130,10 +130,10 @@ function mapsEqual = verifyMapsUnchanged(porwb, inftype, torf, matorimg)
 	
 	% List all files for testing
 	if strcmp(matorimg, 'img')
-		files = ls("*.nii");
+		files = ls('*.nii');
 		filetype = 'nii';
 	else
-		files = ls("swe_*.mat");
+		files = ls('swe_*.mat');
 		filetype = 'mat';
 	end
 
@@ -160,8 +160,8 @@ function mapsEqual = verifyMapsUnchanged(porwb, inftype, torf, matorimg)
 		else
 
 			% Read in the surface data.
-			file = load(strrep(file, " ", ""));
-			gt_file = load(strrep(gt_file, " ", ""));
+			file = load(strrep(file, ' ', ''));
+			gt_file = load(strrep(gt_file, ' ', ''));
 
 			% Retrieve field name.
 			fieldname = fieldnames(file){1};


### PR DESCRIPTION
The goal of this PR is to remove any use of the double quotation syntax. There are two reasons for this:

1. The double quotation syntax is not available in old versions of Matlab (older than R2017a)
2. The double quotation syntax yields a string and not a char array like the simple quotation syntax

The difficulty was to find every use in the code as a simple search of the `"` character yielded hundreds of match for it. Nonetheless, I went through all the files in the code and it seems that I caught every double-quote syntax use.

 As it is a very simple modification of the code, I think this PR is ready to be merged.
