### PR TITLE
[WIP] Fix a bug occurring when an entire chunk of data is masked out

### DIFF
--- a/swe_cp.m
+++ b/swe_cp.m
@@ -824,7 +824,9 @@ if ~isMat
       %-Write beta files
       %----------------------------------------------------------------------
       for iBeta=1:nBeta
-        c(cmask) = beta(iBeta,:);
+        if CrS
+          c(cmask) = beta(iBeta,:);
+        end
         Vbeta(iBeta) = swe_data_write(Vbeta(iBeta), c, chunk); 
       end
 
@@ -832,7 +834,9 @@ if ~isMat
       %----------------------------------------------------------------------
       if isfield(SwE.type,'modified') 
         for iCov_vis=1:nCov_vis
-          c(cmask) = Cov_vis(iCov_vis,:);
+          if CrS
+            c(cmask) = Cov_vis(iCov_vis,:);
+          end
           Vcov_vis(iCov_vis) = swe_data_write(Vcov_vis(iCov_vis), c, chunk);
         end
       end
@@ -840,7 +844,9 @@ if ~isMat
       %-Write CovBeta files
       %----------------------------------------------------------------------
       for iCov_beta=1:nCov_beta
-        c(cmask) = Cov_beta(iCov_beta,:);
+        if CrS
+          c(cmask) = Cov_beta(iCov_beta,:);
+        end
         Vcov_beta(iCov_beta) = swe_data_write(Vcov_beta(iCov_beta), c, chunk);
       end
       
@@ -1047,13 +1053,17 @@ else % matrix input
     clear mask
 
     beta = zeros(nBeta, nVox);
-    beta(:,cmask) = crBeta;
+    if CrS
+      beta(:,cmask) = crBeta;
+    end
     save(sprintf('swe_%s_beta_b%s',file_data_type,file_ext), 'beta');
     clear beta crBeta
 
     if isfield(SwE.type,'modified')
         cov_vis = zeros(nCov_vis, nVox);
-        cov_vis(:,cmask) = crCov_vis;
+        if CrS
+          cov_vis(:,cmask) = crCov_vis;
+        end
         save(sprintf('swe_%s_cov_vv%s',file_data_type,file_ext), 'cov_vis');
         clear cov_vis crCov_vis
     end

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1104,47 +1104,63 @@ if ~isMat
     %-Write beta files
     %----------------------------------------------------------------------
     for iBeta = 1:nBeta
-      c(cmask) = beta(iBeta,:);
+      if CrS
+        c(cmask) = beta(iBeta,:);
+      end
       Vbeta(iBeta) = swe_data_write(Vbeta(iBeta), c, chunk); 
     end
 
     %-Write WB fitted data images
     %------------------------------------------------------------------
     for iScan = 1:nScan
-      c(cmask) = YWB(iScan,:);
+      if CrS
+        c(cmask) = YWB(iScan,:);
+      end
       VYWB(iScan) = swe_data_write(VYWB(iScan), c, chunk);
     end
     
     %-Write WB residuals
     %------------------------------------------------------------------
     for iScan = 1:nScan
-      c(cmask) = resWB(iScan,:);
+      if CrS
+        c(cmask) = resWB(iScan,:);
+      end
       VResWB(iScan) = swe_data_write(VResWB(iScan), c, chunk);
     end
 
     %-Write parametric score image of the original data
     %------------------------------------------------------------------
-    c(cmask) = score;
+    if CrS
+      c(cmask) = score;
+    end
     Vscore = swe_data_write(Vscore,  c, chunk);
     
     %-Write parametric edf image of the original data
     %------------------------------------------------------------------
-    c(cmask) = hyptest.positive.edf;
+    if CrS
+      c(cmask) = hyptest.positive.edf;
+    end
     Vedf = swe_data_write(Vedf,  c, chunk);
     
     %-Write parametric p-value image
     %------------------------------------------------------------------
-    c(cmask) = -log10(hyptest.positive.p);
+    if CrS
+      c(cmask) = -log10(hyptest.positive.p);
+    end
     VlP = swe_data_write(VlP,  c, chunk);
     
     if WB.stat=='T'
-      c(cmask) = -log10(hyptest.negative.p);
+      if CrS
+        c(cmask) = -log10(hyptest.negative.p);
+      end
       VlP_Neg = swe_data_write(VlP_Neg,  c, chunk);
     end
     
     %-Write converted parametric score image of the original data
     %------------------------------------------------------------------
-    c(cmask) = hyptest.positive.conScore;
+    if CrS
+      c(cmask) = hyptest.positive.conScore;
+    end
     VcScore = swe_data_write(VcScore,  c, chunk);
 
     if WB.stat == 'T'


### PR DESCRIPTION
The goal of this PR is to fix a bug occurring when an entire chunk of data would be masked out. In this scenario, the toolbox would skip the computation of results for this chunk of data but attempt to save them in an empty variable. If this was the first chunk of data, the result variables of this chunk of data would not have been created and, if it was a later chunk of data, the result variables of the previous chunk of data would actually be kept in memory. As the toolbox would attempt to assign these results variables to an empty variable, the toolbox would throw an error. 

With this PR, the toolbox checks now if each chunk of data has been completely masked out or not. If it is the case, it skips the variable assignment, preventing any erroneous assignment.

The changes are minimal and should fix the issue noted above, but I still need to test the PR on a pathological case to see if there exist other side effects that would occur when an entire chunk of data is masked out.
