### PR TITLE
Replace the function 'replace' by the function 'strrep' as it is compatible with older Matlab versions

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -59,8 +59,8 @@ switch lower(Action)
         %==================================================================
     case 'asciiwelcome'                          %-ASCII swe banner welcome
         %==================================================================
-        tmp = replace(versionNo,'.rc2','');
-        tmp = replace(tmp,'.rc','');
+        tmp = strrep(versionNo,'.rc2','');
+        tmp = strrep(tmp,'.rc','');
         a = generateAscii(['SwE v' tmp]);
         fprintf('%s \n', a{1}, a{2}, a{3}, a{4});
         fprintf('swe v%s \n', versionNo);


### PR DESCRIPTION
The goal of this PR is to replace the relatively recent Matlab function `replace` (introduced in R2016b) by the much older Matlab function `strrep` (introduced before R2006a) in order to allow the use of the toolbox with old Matlab versions.

@nicholst, this PR is straightforward and I think we can merge it straightaway.