### PR TITLE
Display scaled design matrix

### DIFF
--- a/swe_conman.m
+++ b/swe_conman.m
@@ -633,8 +633,8 @@ switch lower(varargin{1})
         %-Picture design matrix
         %------------------------------------------------------------------
         axes(h)
-        if isfield(varargin{2},'nKX') && ~isempty(varargin{2}.X)
-            hDesMtxIm = image((varargin{2}.X+1)*32);
+        if isfield(varargin{2},'nKX') && ~isempty(varargin{2}.nKX)
+            hDesMtxIm = image((varargin{2}.nKX+1)*32);
         else
             hDesMtxIm = image(...
                 (spm_DesMtx('sca',varargin{2}.X,varargin{2}.name)+1)*32);

--- a/swe_cp.m
+++ b/swe_cp.m
@@ -1119,6 +1119,7 @@ end
 % end
 SwE.VM         = VM;                %-Filehandle - Mask
 
+xX.nKX         = spm_DesMtx('sca',xX.X,xX.name); %-Scaled DesMtx for display
 SwE.xX         = xX;                %-design structure
 SwE.xM         = xM;                %-mask structure
 

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -1735,6 +1735,7 @@ if isfield(SwE.type,'modified')
 end
 SwE.VM         = VM;                %-Filehandle - Mask
 
+xX.nKX         = spm_DesMtx('sca',xX.X,xX.name); %-Scaled DesMtx for display
 SwE.xX         = xX;                %-design structure
 SwE.xM         = xM;                %-mask structure
 

--- a/swe_results_ui.m
+++ b/swe_results_ui.m
@@ -616,8 +616,8 @@ switch lower(Action), case 'setup'                         %-Set up results
     %-Plot design matrix
     %----------------------------------------------------------------------
     hDesMtx   = axes('Parent',Fgraph,'Position',[0.65 0.55 0.25 0.25]);
-    hDesMtxIm = image((SwE.xX.X + 1)*32);
-    xlabel('Design matrix')
+    hDesMtxIm = image((SwE.xX.nKX + 1)*32,'Parent',hDesMtx);
+    xlabel(hDesMtx,'Design matrix','FontSize',FS(10))
     set(hDesMtxIm,'ButtonDownFcn','spm_DesRep(''SurfDesMtx_CB'')',...
         'UserData',struct(...
         'X',        SwE.xX.X,...


### PR DESCRIPTION
SPM uses some arbitrary heuristics to create a visually appealing design matrix, saved as the variable `xX.nKX`.  While currently, this scaled design matrix is shown when the model is configured (https://github.com/NISOx-BDI/SwE-toolbox/blob/master/swe_run_smodel.m#L888), later when the model is actually examined in Results the raw design matrix `xX.X` is used (https://github.com/NISOx-BDI/SwE-toolbox/blob/master/swe_results_ui.m#L619).

This PR does two things: (1) It changes `swe_results_ui` to use `xX.nKX` and (2) it adds code to `swe_cp` and `swe_cp_WB` to ensure that variable is created.  (In `swe_run_smodel`, `swe_DesRep` is called which creates `xX.nKX` if it doesn't exist.  The edits to `swe_results_ui` were made in reference to the current SPM12 `spm_results_ui` and I took the opportunity to rebase and add explicit reference the graphic handles. (Hopefully that doesn't come back to bite us). 

As a side note, the name `nKX` alludes to `KX` which is the filtered/whitened design matrix; as we always use an identity working covariance matrix KX = X.