### PR TITLE
Ensure the variable cmask is a row vector for CIfTI and GIFTI

### DIFF
--- a/swe_cp.m
+++ b/swe_cp.m
@@ -661,6 +661,11 @@ if ~isMat
       %------------------------------------------------------------------
       Y = zeros(nScan, numel(chunk));
       cmask = mask(chunk);
+      
+      if size(cmask, 2) == 1
+        cmask = cmask';
+      end
+      
       for iScan=1:nScan
         if ~any(cmask), break, end                 %-Break if empty mask
         

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -865,6 +865,11 @@ if ~isMat
     %------------------------------------------------------------------
     Y = zeros(nScan, numel(chunk));
     cmask = mask(chunk);
+          
+    if size(cmask, 2) == 1
+      cmask = cmask';
+    end
+
     for iScan=1:nScan
       if ~any(cmask), break, end                 %-Break if empty mask
       


### PR DESCRIPTION
The goal of this PR is to fix issue #176. The fix checks if the variable `cmask` has a single column and, if it is the case, it transposes it.

Some tests on my computer seem to indicate there is no side effect to do so.  The Travis tests should actually cover this change. Thus, if they pass, I think we can assume that it did not break anything.