### PR TITLE
Fix a bug related to the progress display of parametric analyses

### DIFF
--- a/swe_cp.m
+++ b/swe_cp.m
@@ -856,7 +856,7 @@ if ~isMat
       %-Report progress
       %======================================================================
       fprintf('%s%30s\n',repmat(sprintf('\b'),1,30),'...done');             %-#
-      swe_progress_bar('Set',i);
+      swe_progress_bar('Set',iChunk);
     end % iChunk=1:nbchunks
 
     swe_progress_bar('Clear');


### PR DESCRIPTION
The goal of this PR is to fix a bug related to the progress display of parametric analyses.

Before this PR, the progress display was updated using the variable `i` while it needed to be updated using the variable `iChunk`. This PR fixes this simply by replacing `i` by `iChunk`.
