### PR TITLE
Remove dependence on old spm_matlab_version_chk

### DIFF
--- a/swe_contrasts.m
+++ b/swe_contrasts.m
@@ -757,7 +757,7 @@ SwE.xCon = xCon;
 %--------------------------------------------------------------------------
 if isOctave
     save('SwE.mat','SwE');
-elseif spm_matlab_version_chk('7') >=0
+elseif spm_check_version('matlab','7') >=0
     save('SwE','SwE','-V6');
 else
     save('SwE','SwE');

--- a/swe_cp.m
+++ b/swe_cp.m
@@ -1181,7 +1181,7 @@ SwE.ver = swe('ver');
 fprintf('%-40s: %30s','Saving SwE.mat','...writing');                   %-#
 if isOctave
     save('SwE.mat','SwE');
-elseif spm_matlab_version_chk('7') >=0
+elseif spm_check_version('matlab','7') >=0
     save('SwE','SwE','-V6');
 else
     save('SwE','SwE');

--- a/swe_cp_WB.m
+++ b/swe_cp_WB.m
@@ -270,7 +270,7 @@ if WB.clusterWise == 1 && WB.RSwE ==1
   SwE.WB.RSwE = 0;
   if isOctave
     save('SwE.mat','SwE');
-  elseif spm_matlab_version_chk('7') >=0
+  elseif spm_check_version('matlab','7') >=0
     save('SwE','SwE','-V6');
   else
     save('SwE','SwE');
@@ -1764,7 +1764,7 @@ end
 %--------------------------------------------------------------------------
 if isOctave
   save('SwE.mat','SwE');
-elseif spm_matlab_version_chk('7') >=0
+elseif spm_check_version('matlab','7') >=0
   save('SwE','SwE','-V6');
 else
   save('SwE','SwE');
@@ -2950,7 +2950,7 @@ end
 %Save SwE.
 if isOctave
   save('SwE.mat','SwE');
-elseif spm_matlab_version_chk('7') >=0
+elseif spm_check_version('matlab','7') >=0
   save('SwE','SwE','-V6');
 else
   save('SwE','SwE');


### PR DESCRIPTION
This addresses #165... `spm_matlab_version_chk` has been long depricated; this PR updates it with the modern function, `spm_check_version`.