### PR TITLE
Release SwE Version 2.2.1 

### DIFF
--- a/swe.m
+++ b/swe.m
@@ -11,7 +11,7 @@ function varargout = swe(varargin)
 % Written by Bryan Guillaume
 % Version Info:  $Format:%ci$ $Format:%h$
 
-versionNo = '2.2.1';
+versionNo = '2.2.2';
 
 try
   Modality = spm_get_defaults('modality');


### PR DESCRIPTION
### Changes made since the previous version (v2.2.0)

* fix: Remove dependence on old spm_matlab_version_chk #183
* fix: Removing references to Gaussian Random Field Theory #180
* fix: Fix a bug related to the progress display of parametric analyses #179
* fix: Remove use of double quotes to improve Matlab version compatibility #181

### Links to relevant issues

Issue #165 
Issue #169 

